### PR TITLE
Ensure the extension does not initialize classes just to get their name

### DIFF
--- a/deployment/forbidden-apis-signatures.txt
+++ b/deployment/forbidden-apis-signatures.txt
@@ -1,0 +1,2 @@
+@defaultMessage You should avoid loading a class in deployment module just to use its name. Use full qualified class name string literal instead.
+java.lang.Class#getName()

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -93,6 +93,17 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+
+                <configuration>
+                    <signaturesFiles>
+                        <signaturesFile>forbidden-apis-signatures.txt</signaturesFile>
+                    </signaturesFiles>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/com/tietoevry/quarkus/resteasy/problem/deployment/ProblemProcessor.java
@@ -3,22 +3,7 @@ package com.tietoevry.quarkus.resteasy.problem.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
-import com.tietoevry.quarkus.resteasy.problem.DefaultExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.JacksonProblemModuleRegistrar;
-import com.tietoevry.quarkus.resteasy.problem.JsonBProblemSerializer;
-import com.tietoevry.quarkus.resteasy.problem.ProblemMapper;
 import com.tietoevry.quarkus.resteasy.problem.ProblemRecorder;
-import com.tietoevry.quarkus.resteasy.problem.javax.ConstraintViolationExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.javax.ValidationExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.javax.Violation;
-import com.tietoevry.quarkus.resteasy.problem.jaxrs.JaxRsForbiddenExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.jaxrs.NotFoundExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.jaxrs.WebApplicationExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.misc.JsonProcessingExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.misc.JsonbExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.security.AuthenticationFailedExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.security.ForbiddenExceptionMapper;
-import com.tietoevry.quarkus.resteasy.problem.security.UnauthorizedExceptionMapper;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -30,30 +15,32 @@ import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import java.util.Arrays;
 import java.util.List;
-import javax.ws.rs.ext.ExceptionMapper;
 import org.jboss.logging.Logger;
+
+;
 
 public class ProblemProcessor {
 
     private static final String FEATURE_NAME = "resteasy-problem";
     private static final Logger logger = Logger.getLogger(FEATURE_NAME);
 
-    private static final List<Class<? extends ExceptionMapper<?>>> COMMON_EXCEPTION_MAPPER_CLASSES = Arrays.asList(
-            // TOP LEVEL
-            DefaultExceptionMapper.class,
-            ProblemMapper.class,
+    private static final List<String> EXCEPTION_MAPPER_CLASSES = Arrays.asList(
+            "com.tietoevry.quarkus.resteasy.problem.DefaultExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.ProblemMapper",
 
             // JAXRS
-            WebApplicationExceptionMapper.class,
-            JaxRsForbiddenExceptionMapper.class,
-            NotFoundExceptionMapper.class,
-            UnauthorizedExceptionMapper.class,
-            AuthenticationFailedExceptionMapper.class,
-            ForbiddenExceptionMapper.class,
+            "com.tietoevry.quarkus.resteasy.problem.jaxrs.WebApplicationExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.jaxrs.JaxRsForbiddenExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.jaxrs.NotFoundExceptionMapper",
+
+            // SECURITY
+            "com.tietoevry.quarkus.resteasy.problem.security.UnauthorizedExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.security.AuthenticationFailedExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.security.ForbiddenExceptionMapper",
 
             // JAVAX
-            ValidationExceptionMapper.class,
-            ConstraintViolationExceptionMapper.class);
+            "com.tietoevry.quarkus.resteasy.problem.javax.ValidationExceptionMapper",
+            "com.tietoevry.quarkus.resteasy.problem.javax.ConstraintViolationExceptionMapper");
 
     @BuildStep
     FeatureBuildItem createFeature() {
@@ -62,32 +49,35 @@ public class ProblemProcessor {
 
     @BuildStep(onlyIf = JacksonDetector.class)
     void registerJacksonMapperCustomizer(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
-        additionalBeans.produce(new AdditionalBeanBuildItem(JacksonProblemModuleRegistrar.class));
+        additionalBeans
+                .produce(new AdditionalBeanBuildItem("com.tietoevry.quarkus.resteasy.problem.JacksonProblemModuleRegistrar"));
     }
 
     @BuildStep(onlyIf = JsonBDetector.class)
     void registerJsonbItems(BuildProducer<JsonbSerializerBuildItem> serializers,
             BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-        serializers.produce(new JsonbSerializerBuildItem(JsonBProblemSerializer.class.getName()));
-        providers.produce(new ResteasyJaxrsProviderBuildItem(JsonbExceptionMapper.class.getName()));
+        serializers.produce(new JsonbSerializerBuildItem("com.tietoevry.quarkus.resteasy.problem.JsonBProblemSerializer"));
+        providers.produce(
+                new ResteasyJaxrsProviderBuildItem("com.tietoevry.quarkus.resteasy.problem.misc.JsonbExceptionMapper"));
     }
 
     @BuildStep
     void registerCommonProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-        COMMON_EXCEPTION_MAPPER_CLASSES.stream()
-                .map(Class::getName)
+        EXCEPTION_MAPPER_CLASSES.stream()
                 .map(ResteasyJaxrsProviderBuildItem::new)
                 .forEach(providers::produce);
     }
 
     @BuildStep(onlyIf = JacksonDetector.class)
     void registerJacksonProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-        providers.produce(new ResteasyJaxrsProviderBuildItem(JsonProcessingExceptionMapper.class.getName()));
+        providers.produce(new ResteasyJaxrsProviderBuildItem(
+                "com.tietoevry.quarkus.resteasy.problem.misc.JsonProcessingExceptionMapper"));
     }
 
     @BuildStep
     ReflectiveClassBuildItem registerPojosForReflection() {
-        return new ReflectiveClassBuildItem(true, true, Violation.class.getName());
+        return new ReflectiveClassBuildItem(true, true,
+                "com.tietoevry.quarkus.resteasy.problem.javax.Violation");
     }
 
     @Record(STATIC_INIT)

--- a/pom.xml
+++ b/pom.xml
@@ -11,22 +11,23 @@
 
     <scm>
         <developerConnection>scm:git:git@github.com:TietoEVRY-DataPlatforms/quarkus-resteasy-problem.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler-plugin.version>3.8.1</maven.compiler-plugin.version>
 
         <quarkus.version>1.11.5.Final</quarkus.version>
         <zalando-problem.version>0.24.0</zalando-problem.version>
+        <assertj.version>3.16.1</assertj.version>
 
+        <maven.compiler-plugin.version>3.8.1</maven.compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
-        <assertj.version>3.16.1</assertj.version>
+        <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
     </properties>
 
     <modules>
@@ -110,5 +111,52 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <version>${forbiddenapis-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>verify-forbidden-apis</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                                <excludes>
+                                    <!-- JBoss Logger formats messages according to default Locale (bug or feature?) -->
+                                    <exclude>**/*_$logger.class</exclude>
+                                    <!-- JBoss message bundles format messages -->
+                                    <exclude>**/*_$bundle.class</exclude>
+                                </excludes>
+
+                                <bundledSignatures>
+                                    <!-- These signatures on the top are not specific to any JDK version -->
+                                    <bundledSignature>jdk-system-out</bundledSignature>
+                                    <bundledSignature>jdk-non-portable</bundledSignature>
+                                    <bundledSignature>jdk-reflection</bundledSignature>
+
+                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
+                                    <bundledSignature>jdk-unsafe-1.8</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-11</bundledSignature>
+
+                                    <bundledSignature>jdk-deprecated-1.8</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-11</bundledSignature>
+
+                                    <bundledSignature>jdk-internal-1.8</bundledSignature>
+                                    <bundledSignature>jdk-internal-11</bundledSignature>
+                                </bundledSignatures>
+                                <failOnMissingClasses>false</failOnMissingClasses>
+                                <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -92,6 +92,11 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
forbiddenapi is pretty awesome, it will fail a build if rules are violated. Example log if something goes wrong (forbidden usage of Class::getName()):

```
[INFO] Loading classes to check...
[INFO] Scanning classes for violations...
[ERROR] Forbidden method invocation: java.lang.Class#getName() [You should avoid loading a class in deployment module just to use its name. Use string literal instead.]
[ERROR]   in com.tietoevry.quarkus.resteasy.problem.deployment.ProblemProcessor (ProblemProcessor.java:43)
[ERROR] Scanned 5 class file(s) for forbidden API invocations (in 0.12s), 1 error(s).
```