### PR TITLE
Refactor: processors collection extracted from ExceptionMapperBase

### DIFF
--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
@@ -1,15 +1,12 @@
 package com.tietoevry.quarkus.resteasy.problem;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ExceptionMapper;
 import org.apiguardian.api.API;
-import org.slf4j.LoggerFactory;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.StatusType;
@@ -21,23 +18,7 @@ import org.zalando.problem.StatusType;
 public abstract class ExceptionMapperBase<E extends Throwable> implements ExceptionMapper<E> {
 
     public static final MediaType APPLICATION_PROBLEM_JSON = new MediaType("application", "problem+json");
-
-    private static final List<ProblemProcessor> processors = new CopyOnWriteArrayList<>();
-
-    static {
-        resetProcessors();
-    }
-
-    static synchronized void resetProcessors() {
-        processors.clear();
-        registerProcessor(new LoggingProcessor(LoggerFactory.getLogger("http-problem")));
-        registerProcessor(new ProblemDefaultsProvider());
-    }
-
-    static synchronized void registerProcessor(ProblemProcessor processor) {
-        processors.add(processor);
-        processors.sort(ProblemProcessor.DEFAULT_ORDERING);
-    }
+    public static final PostProcessorsRegistry postProcessorsRegistry = new PostProcessorsRegistry();
 
     @Context
     UriInfo uriInfo;
@@ -46,10 +27,8 @@ public abstract class ExceptionMapperBase<E extends Throwable> implements Except
     public final Response toResponse(E exception) {
         Problem problem = toProblem(exception);
         ProblemContext context = new ProblemContext(exception, uriInfo);
-        for (ProblemProcessor processor : processors) {
-            problem = processor.apply(problem, context);
-        }
-        return toResponse(problem, exception);
+        Problem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);
+        return toResponse(finalProblem, exception);
     }
 
     protected abstract Problem toProblem(E exception);

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/PostProcessorsRegistry.java
@@ -1,0 +1,45 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+import org.zalando.problem.Problem;
+
+/**
+ * Container for prioritised list of Problem post-processors.
+ */
+class PostProcessorsRegistry {
+
+    private final List<ProblemProcessor> processors = new ArrayList<>();
+
+    public PostProcessorsRegistry() {
+        reset();
+    }
+
+    synchronized void reset() {
+        processors.clear();
+        register(new LoggingProcessor(LoggerFactory.getLogger("http-problem")));
+        register(new ProblemDefaultsProvider());
+    }
+
+    synchronized void register(ProblemProcessor processor) {
+        processors.add(processor);
+        processors.sort(ProblemProcessor.DEFAULT_ORDERING);
+    }
+
+    /**
+     * Applies all registered post-processors on given Problem, in prioritized order.
+     *
+     * @param problem Original Problem produced by Exception Mapper
+     * @param context Additional info on cause (original exception caught by ExceptionMapper) and HTTP request
+     * @return Enhanced version of original Problem
+     */
+    public Problem applyPostProcessing(Problem problem, ProblemContext context) {
+        for (ProblemProcessor processor : processors) {
+            problem = processor.apply(problem, context);
+        }
+        return problem;
+    }
+
+}

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemRecorder.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemRecorder.java
@@ -7,16 +7,17 @@ import java.util.Set;
 public class ProblemRecorder {
 
     public void reset() {
-        ExceptionMapperBase.resetProcessors();
+        ExceptionMapperBase.postProcessorsRegistry.reset();
     }
 
     public void configureMdc(Set<String> includeMdcProperties) {
         if (!includeMdcProperties.isEmpty()) {
-            ExceptionMapperBase.registerProcessor(new MdcPropertiesProcessor(includeMdcProperties));
+            ExceptionMapperBase.postProcessorsRegistry.register(new MdcPropertiesProcessor(includeMdcProperties));
         }
     }
 
     public void enableMetrics() {
-        ExceptionMapperBase.registerProcessor(new HttpErrorMetricsProcessor());
+        ExceptionMapperBase.postProcessorsRegistry.register(new HttpErrorMetricsProcessor());
     }
+
 }

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/PostProcessorsRegistryTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/PostProcessorsRegistryTest.java
@@ -1,0 +1,68 @@
+package com.tietoevry.quarkus.resteasy.problem;
+
+import static com.tietoevry.quarkus.resteasy.problem.ProblemContextMother.simpleContext;
+import static com.tietoevry.quarkus.resteasy.problem.ProblemMother.badRequestProblem;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.zalando.problem.Problem;
+
+class PostProcessorsRegistryTest {
+
+    static final int HIGHEST = 11;
+    static final int MEDIUM = 10;
+    static final int LOW = 9;
+
+    PostProcessorsRegistry registry = new PostProcessorsRegistry();
+    List<Integer> invocations = new ArrayList<>();
+
+    @Test
+    void shouldIterateFromHighestToLowestPriority() {
+        registry.register(processorWithPriority(MEDIUM));
+        registry.register(processorWithPriority(LOW));
+        registry.register(processorWithPriority(HIGHEST));
+
+        registry.applyPostProcessing(badRequestProblem().build(), simpleContext());
+
+        assertThat(invocations).containsExactly(HIGHEST, MEDIUM, LOW);
+    }
+
+    @Test
+    void shouldTolerateDuplicates() {
+        registry.register(processorWithPriority(MEDIUM));
+        registry.register(processorWithPriority(HIGHEST));
+        registry.register(processorWithPriority(MEDIUM));
+        registry.register(processorWithPriority(MEDIUM));
+
+        registry.applyPostProcessing(badRequestProblem().build(), simpleContext());
+
+        assertThat(invocations).containsExactly(HIGHEST, MEDIUM, MEDIUM, MEDIUM);
+    }
+
+    ProblemProcessor processorWithPriority(int priority) {
+        return new TestProcessor(priority);
+    }
+
+    class TestProcessor implements ProblemProcessor {
+
+        final int priority;
+
+        TestProcessor(int priority) {
+            this.priority = priority;
+        }
+
+        @Override
+        public Problem apply(Problem problem, ProblemContext problemContext) {
+            invocations.add(priority);
+            return problem;
+        }
+
+        @Override
+        public int priority() {
+            return priority;
+        }
+    }
+
+}


### PR DESCRIPTION
It will make it easier to move into SPI direction, and ExceptionMapperBase is much more clean now - it becomes just a consumer of this registry, not manager-and-consumer.