### PR TITLE
Removed unstable api from ExceptionMapperBase

### DIFF
--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ExceptionMapperBase.java
@@ -1,12 +1,12 @@
 package com.tietoevry.quarkus.resteasy.problem;
 
+import static com.tietoevry.quarkus.resteasy.problem.ProblemUtils.APPLICATION_PROBLEM_JSON;
+
 import java.util.Objects;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ExceptionMapper;
-import org.apiguardian.api.API;
 import org.zalando.problem.Problem;
 
 /**
@@ -15,7 +15,6 @@ import org.zalando.problem.Problem;
  */
 public abstract class ExceptionMapperBase<E extends Throwable> implements ExceptionMapper<E> {
 
-    public static final MediaType APPLICATION_PROBLEM_JSON = new MediaType("application", "problem+json");
     public static final PostProcessorsRegistry postProcessorsRegistry = new PostProcessorsRegistry();
 
     @Context
@@ -28,16 +27,12 @@ public abstract class ExceptionMapperBase<E extends Throwable> implements Except
 
         ProblemContext context = ProblemContext.of(exception, uriInfo);
         Problem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);
-        return toResponse(finalProblem, exception);
+        return toResponse(finalProblem);
     }
 
     protected abstract Problem toProblem(E exception);
 
-    /**
-     * This is an internal API. It may be changed or removed without notice in any release.
-     */
-    @API(status = API.Status.INTERNAL)
-    protected Response toResponse(Problem problem, E originalException) {
+    private Response toResponse(Problem problem) {
         Objects.requireNonNull(problem.getStatus());
 
         return Response

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemUtils.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/ProblemUtils.java
@@ -1,9 +1,12 @@
 package com.tietoevry.quarkus.resteasy.problem;
 
+import javax.ws.rs.core.MediaType;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ProblemBuilder;
 
 public final class ProblemUtils {
+
+    public static final MediaType APPLICATION_PROBLEM_JSON = new MediaType("application", "problem+json");
 
     private ProblemUtils() {
     }

--- a/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
+++ b/runtime/src/main/java/com/tietoevry/quarkus/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
@@ -1,11 +1,17 @@
 package com.tietoevry.quarkus.resteasy.problem.jaxrs;
 
+import static com.tietoevry.quarkus.resteasy.problem.ProblemUtils.APPLICATION_PROBLEM_JSON;
+
 import com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase;
+import com.tietoevry.quarkus.resteasy.problem.ProblemContext;
+import java.util.Objects;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.problem.Problem;
@@ -15,12 +21,22 @@ import org.zalando.problem.Status;
  * Generic exception mapper for JaxRS WebApplicationExceptions - it passes status and message to application/problem response.
  */
 @Priority(Priorities.USER)
-public class WebApplicationExceptionMapper extends ExceptionMapperBase<WebApplicationException> {
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
 
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationExceptionMapper.class);
 
+    @Context
+    UriInfo uriInfo;
+
     @Override
-    protected Problem toProblem(WebApplicationException exception) {
+    public final Response toResponse(WebApplicationException exception) {
+        Problem problem = toProblem(exception);
+        ProblemContext context = ProblemContext.of(exception, uriInfo);
+        Problem finalProblem = ExceptionMapperBase.postProcessorsRegistry.applyPostProcessing(problem, context);
+        return toResponse(finalProblem, exception);
+    }
+
+    private Problem toProblem(WebApplicationException exception) {
         Status status = Status.INTERNAL_SERVER_ERROR;
         try {
             status = Status.valueOf(exception.getResponse().getStatus());
@@ -31,22 +47,22 @@ public class WebApplicationExceptionMapper extends ExceptionMapperBase<WebApplic
         return Problem.valueOf(status, exception.getMessage());
     }
 
-    @Override
-    protected Response toResponse(Problem problem, WebApplicationException originalException) {
-        Response problemResponse = super.toResponse(problem, originalException);
+    private Response toResponse(Problem problem, WebApplicationException originalException) {
+        Objects.requireNonNull(problem.getStatus());
 
-        Response originalResponse = originalException.getResponse();
-        if (originalResponse == null || originalResponse.getHeaders().isEmpty()) {
-            return problemResponse;
+        Response.ResponseBuilder responseBuilder = Response
+                .status(problem.getStatus().getStatusCode())
+                .type(APPLICATION_PROBLEM_JSON)
+                .entity(problem);
+
+        if (originalException.getResponse() != null) {
+            originalException
+                    .getResponse()
+                    .getHeaders()
+                    .forEach((header, values) -> values.forEach(value -> responseBuilder.header(header, value)));
         }
 
-        return withHeaders(problemResponse, originalResponse.getHeaders());
-    }
-
-    private Response withHeaders(Response problemResponse, MultivaluedMap<String, Object> additionalHeaders) {
-        Response.ResponseBuilder responseBuilder = Response.fromResponse(problemResponse);
-        additionalHeaders.forEach(
-                (header, values) -> values.forEach(value -> responseBuilder.header(header, value)));
         return responseBuilder.build();
     }
+
 }

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/javax/ConstraintViolationExceptionMapperTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/javax/ConstraintViolationExceptionMapperTest.java
@@ -1,6 +1,6 @@
 package com.tietoevry.quarkus.resteasy.problem.javax;
 
-import static com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase.APPLICATION_PROBLEM_JSON;
+import static com.tietoevry.quarkus.resteasy.problem.ProblemUtils.APPLICATION_PROBLEM_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;

--- a/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/jaxrs/WebApplicationExceptionMapperTest.java
+++ b/runtime/src/test/java/com/tietoevry/quarkus/resteasy/problem/jaxrs/WebApplicationExceptionMapperTest.java
@@ -1,6 +1,6 @@
 package com.tietoevry.quarkus.resteasy.problem.jaxrs;
 
-import static com.tietoevry.quarkus.resteasy.problem.ExceptionMapperBase.APPLICATION_PROBLEM_JSON;
+import static com.tietoevry.quarkus.resteasy.problem.ProblemUtils.APPLICATION_PROBLEM_JSON;
 import static javax.ws.rs.core.HttpHeaders.RETRY_AFTER;
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
@pazkooda addressing your concerns from one of the previous PR (the one that fixed missing headers) - WebApplicationExceptionMapper no longer extends ExceptionMapperBase - we're trading cleaner api over some duplication.