### PR TITLE
fix NullPointerException that would occur when WebApplicationException was thrown with an unassigned Http Status Code

### DIFF
--- a/integration-test/src/test/java/io/quarkiverse/resteasy/problem/JaxRsMappersIT.java
+++ b/integration-test/src/test/java/io/quarkiverse/resteasy/problem/JaxRsMappersIT.java
@@ -6,6 +6,7 @@ import static jakarta.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -36,6 +37,19 @@ class JaxRsMappersIT {
                 .body("title", equalTo(Response.Status.fromStatusCode(status).getReasonPhrase()))
                 .body("status", equalTo(status))
                 .body("stacktrace", nullValue());
+    }
+
+    @ParameterizedTest(name = "http status: {0}")
+    @ValueSource(ints = { 318, 499, 533 })
+    void webApplicationExceptionWithUnassignedHttpStatusCodeShouldNotFail(int status) {
+        given()
+            .queryParam("status", status)
+            .get("/throw/jax-rs/web-application-exception")
+            .then()
+            .statusCode(status)
+            .body("title", equalToIgnoringCase("Unknown Code"))
+            .body("status", equalTo(status))
+            .body("stacktrace", nullValue());
     }
 
     @Test

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
@@ -18,7 +18,7 @@ public final class WebApplicationExceptionMapper extends ExceptionMapperBase<Web
 
     @Override
     protected HttpProblem toProblem(WebApplicationException exception) {
-        Response.StatusType status = Response.Status.fromStatusCode(exception.getResponse().getStatus());
+        Response.StatusType status = exception.getResponse().getStatusInfo();
 
         HttpProblem.Builder problem = HttpProblem.builder()
                 .withTitle(status.getReasonPhrase())
@@ -32,5 +32,4 @@ public final class WebApplicationExceptionMapper extends ExceptionMapperBase<Web
 
         return problem.build();
     }
-
 }


### PR DESCRIPTION
At my company, some endpoints return non-standard HTTP Status Codes.

These cause `WebApplicationExceptionMapper` to throw a NullPointerException because 
`Response.StatusType status = Response.Status.fromStatusCode(statusCode);` returns null and then `status.getReasonPhrase())` throws the exception.
This ultimate results in the error not being mapped to a HttpProblem.

This PR fixes that by setting the title of the problem to `Unknown HTTP Status Code` instead, if the above fails.