### PR TITLE
#482 Support for application/problem+json deserialization for RestClients

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        it_modules: ["openapi", "metrics", "zalando"]
+        it_modules: ["openapi", "metrics", "zalando", "rest-client"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ./mvnw install -Pquick
 
       - name: Integration Tests - Core
-        run: ./mvnw clean verify -P it,${{ matrix.maven_profiles }} -pl 'integration-test/core'
+        run: ./mvnw clean verify -P it,${{ matrix.maven_profiles }} -pl 'integration-test/core,integration-test/rest-client'
 
   test-extensions:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        it_modules: ["openapi", "metrics", "zalando", "rest-client"]
+        it_modules: ["openapi", "metrics", "zalando"] # rest-client runs along with core as it utilizes same maven profiles
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/native-mode-tests.yaml
+++ b/.github/workflows/native-mode-tests.yaml
@@ -9,7 +9,7 @@ jobs:
   test-core-native:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         maven_profiles: ["jackson-classic", "jsonb-classic", "jackson-reactive", "jsonb-reactive"]
 
@@ -34,12 +34,12 @@ jobs:
         run: ./mvnw install -Pquick
 
       - name: Native Tests
-        run: ./mvnw clean verify -P it,native,${{ matrix.maven_profiles }} -pl 'integration-test/core'
+        run: ./mvnw clean verify -P it,native,${{ matrix.maven_profiles }} -pl 'integration-test/core,integration-test/rest-client'
 
   test-extensions-native:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         it_modules: ["openapi", "metrics", "zalando", "rest-client"]
       fail-fast: false

--- a/.github/workflows/native-mode-tests.yaml
+++ b/.github/workflows/native-mode-tests.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        it_modules: ["openapi", "metrics", "zalando", "rest-client"]
+        it_modules: ["openapi", "metrics", "zalando"] # rest-client runs along with core as it utilizes same maven profiles
       fail-fast: false
 
     steps:

--- a/.github/workflows/native-mode-tests.yaml
+++ b/.github/workflows/native-mode-tests.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        it_modules: ["openapi", "metrics", "zalando"]
+        it_modules: ["openapi", "metrics", "zalando", "rest-client"]
       fail-fast: false
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ or add your own suggestions and start discussion. Then create fork or branch and
 Quarkus has a strictly enforced code style, so as this extension. Code formatting is done by the Eclipse code formatter, using the config files
 found in the `ide-config` directory. By default when you run `./mvnw install` the code will be formatted automatically.
 
-If you want to run the formatting without doing a full build, you can run `./mvnw process-sources` or `./mvnw formatter:format`.
+If you want to run the formatting without doing a full build, you can run `./mvnw process-sources -P it` or `./mvnw formatter:format -P it`.
 
 More details on how to setup your ide can be found in official [Quarkus Contributing guide](https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md#ide-config-and-code-style)
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ Exceptions transformed into http 500s (aka server errors) will be logged as `ERR
 You may also want to check [this article](https://dzone.com/articles/when-http-status-codes-are-not-enough-tackling-web) on RFC7807 practical usage.  
 More on throwing problems: [zalando/problem usage](https://github.com/zalando/problem#usage)
 
+## RestClients (available since <a href="https://github.com/quarkiverse/quarkus-resteasy-problem/releases/tag/3.20.0">v3.20.0</a>)
+If you use RestClients and your upstream services return `application/problem+json` responses, you can register `ThrowingHttpProblemClientExceptionMapper` for your client to get automatic deserialization and rethrowing `HttpProblem` instead of `ClientWebApplicationException` 
+
+```java
+@RegisterRestClient(configKey = "my-rest-client")
+@RegisterProvider(value = ThrowingHttpProblemClientExceptionMapper.class)
+public interface MyRestClient {
+    @GET
+    @Path("/resource")
+    void getResource();
+}
+```
+
 ## OpenAPI integration (available since <a href="https://github.com/quarkiverse/quarkus-resteasy-problem/releases/tag/3.20.0">v3.20.0</a>)
 When `quarkus-smallrye-openapi` is in the classpath, this extension provides a bunch of out-of-the-box features :
 

--- a/deployment/src/main/java/io/quarkiverse/resteasy/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/resteasy/problem/deployment/ProblemProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.jsonb.spi.JsonbDeserializerBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
@@ -143,9 +144,12 @@ public class ProblemProcessor {
     }
 
     @BuildStep(onlyIf = JsonBDetector.class)
-    void registerJsonbItems(BuildProducer<JsonbSerializerBuildItem> serializers) {
+    void registerJsonbItems(BuildProducer<JsonbSerializerBuildItem> serializers,
+            BuildProducer<JsonbDeserializerBuildItem> deserializers) {
         serializers.produce(
                 new JsonbSerializerBuildItem(EXTENSION_MAIN_PACKAGE + "jsonb.JsonbProblemSerializer"));
+        deserializers.produce(
+                new JsonbDeserializerBuildItem(EXTENSION_MAIN_PACKAGE + "jsonb.JsonbProblemDeserializer"));
     }
 
     /**

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -99,6 +99,7 @@
                 <module>openapi</module>
                 <module>metrics</module>
                 <module>zalando</module>
+                <module>rest-client</module>
             </modules>
         </profile>
 

--- a/integration-test/rest-client/pom.xml
+++ b/integration-test/rest-client/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.resteasy-problem</groupId>
+        <artifactId>quarkus-resteasy-problem-integration-test</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-resteasy-problem-integration-test-restclient</artifactId>
+    <name>Quarkus - RESTeasy - Problem - Integration Tests - Rest Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-test/rest-client/pom.xml
+++ b/integration-test/rest-client/pom.xml
@@ -11,14 +11,36 @@
     <artifactId>quarkus-resteasy-problem-integration-test-restclient</artifactId>
     <name>Quarkus - RESTeasy - Problem - Integration Tests - Rest Client</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
-        </dependency>
-    </dependencies>
+    <profiles>
+        <profile>
+            <id>jackson</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-client-jackson</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>jsonb</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-jsonb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-rest-client-jsonb</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/integration-test/rest-client/pom.xml
+++ b/integration-test/rest-client/pom.xml
@@ -13,10 +13,23 @@
 
     <profiles>
         <profile>
-            <id>jackson</id>
+            <id>jackson-classic</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-resteasy-jackson</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-resteasy-client-jackson</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jackson-reactive</id>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>
@@ -30,7 +43,20 @@
         </profile>
 
         <profile>
-            <id>jsonb</id>
+            <id>jsonb-classic</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-resteasy-jsonb</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-resteasy-client-jsonb</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jsonb-reactive</id>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/DemoResource.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/DemoResource.java
@@ -5,13 +5,24 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
 public class DemoResource {
+
+    @GET
+    @Path("/throw")
+    @Produces()
+    public Response throwProblem() {
+        throw HttpProblem.builder()
+                .withStatus(409)
+                .withTitle("Conflict from upstream service")
+                .withDetail("Nothing to add")
+                .build();
+    }
 
     @Inject
     @RestClient
@@ -20,17 +31,17 @@ public class DemoResource {
     @GET
     @Path("/throw-via-rest-client")
     public void throwViaRestClient() {
-        selfClient.doThrow(418, "I'm a teapot", "Nothing to add");
+        selfClient.doThrow();
     }
 
+    @Inject
+    @RestClient
+    SelfRestClientWithExceptionMapper selfClientWithMapper;
+
     @GET
-    @Path("/throw")
-    public void throwProblem(@QueryParam("status") int status, @QueryParam("title") String title,
-                             @QueryParam("detail") String detail) {
-        throw HttpProblem.builder()
-                .withTitle(title)
-                .withStatus(status)
-                .withDetail(detail)
-                .build();
+    @Path("/throw-via-rest-client-with-mapper")
+    public void throwViaRestClientWithMapper() {
+        selfClientWithMapper.doThrow();
     }
+
 }

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/DemoResource.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/DemoResource.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class DemoResource {
+
+    @Inject
+    @RestClient
+    SelfRestClient selfClient;
+
+    @GET
+    @Path("/throw-via-rest-client")
+    public void throwViaRestClient() {
+        selfClient.doThrow(418, "I'm a teapot", "Nothing to add");
+    }
+
+    @GET
+    @Path("/throw")
+    public void throwProblem(@QueryParam("status") int status, @QueryParam("title") String title,
+                             @QueryParam("detail") String detail) {
+        throw HttpProblem.builder()
+                .withTitle(title)
+                .withStatus(status)
+                .withDetail(detail)
+                .build();
+    }
+}

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClient.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClient.java
@@ -2,14 +2,11 @@ package io.quarkiverse.resteasy.problem.client;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.QueryParam;
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "self")
-@RegisterProvider(value = HttpProblemClientExceptionMapper.class)
 public interface SelfRestClient {
     @GET
     @Path("/throw")
-    void doThrow(@QueryParam("status") int status, @QueryParam("title") String title, @QueryParam("detail") String detail);
+    void doThrow();
 }

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClient.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClient.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "self")
+@RegisterProvider(value = HttpProblemClientExceptionMapper.class)
+public interface SelfRestClient {
+    @GET
+    @Path("/throw")
+    void doThrow(@QueryParam("status") int status, @QueryParam("title") String title, @QueryParam("detail") String detail);
+}

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClientWithExceptionMapper.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/resteasy/problem/client/SelfRestClientWithExceptionMapper.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "self-with-mapper")
+@RegisterProvider(value = ThrowingHttpProblemClientExceptionMapper.class)
+public interface SelfRestClientWithExceptionMapper extends SelfRestClient {
+}

--- a/integration-test/rest-client/src/main/resources/application.properties
+++ b/integration-test/rest-client/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 quarkus.rest-client.self.url=http://localhost:${quarkus.http.port}/
-
 %test.quarkus.rest-client.self.url=http://localhost:${quarkus.http.test-port}/
+
+quarkus.rest-client.self-with-mapper.url=http://localhost:${quarkus.http.port}/
+%test.quarkus.rest-client.self-with-mapper.url=http://localhost:${quarkus.http.test-port}/

--- a/integration-test/rest-client/src/main/resources/application.properties
+++ b/integration-test/rest-client/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.rest-client.self.url=http://localhost:${quarkus.http.port}/
+
+%test.quarkus.rest-client.self.url=http://localhost:${quarkus.http.test-port}/

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
@@ -3,10 +3,10 @@ package io.quarkiverse.resteasy.problem.client;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
@@ -16,25 +16,18 @@ class RestClientIT {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    /**
-     * Reproducer for https://github.com/quarkiverse/quarkus-resteasy-problem/issues/429
-     * <p>
-     * Problem dissapears when `quarkus-resteasy-problem` is not in the classpath, but the reason why it happens is unclear.
-     * <p>
-     * Also, the issue exists only when using reactive rest stack, it works fine in classic (blocking) mode.
-     * <p>
-     * Adding ClientExceptionMapper to RestClient fixes the problem, but IMO it's not a fix, but rather walkaround.
-     */
     @Test
-    @Disabled
     void shouldCallItselfViaRestApiWithoutClientExceptionMapper() {
+        String resteasyClassicDetail = "HTTP 409 Conflict";
+        String resteasyReactiveDetail = "Received: 'Conflict, status code 409' when invoking REST Client method: 'io.quarkiverse.resteasy.problem.client.SelfRestClient#doThrow'";
+
         given()
                 .accept(ContentType.JSON)
                 .get("/throw-via-rest-client")
                 .then()
                 .statusCode(409)
                 .body("title", equalTo("Conflict"))
-                .body("detail", equalTo("HTTP 409 Conflict"))
+                .body("detail", either(equalTo(resteasyClassicDetail)).or(equalTo(resteasyReactiveDetail)))
                 .body("instance", equalTo("/throw-via-rest-client"));
     }
 

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusTest
+class RestClientIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void shouldCallItselfViaRestApiAndRethrowHttpProblemWithOverridenInstance() {
+        given()
+                .accept(ContentType.JSON)
+                .get("/throw-via-rest-client")
+                .then()
+                .statusCode(418)
+                .body("title", equalTo("I'm a teapot"))
+                .body("detail", equalTo("Nothing to add"))
+                .body("instance", equalTo("/throw-via-rest-client"));
+    }
+
+}

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
@@ -15,16 +15,37 @@ class RestClientIT {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
+    /**
+     * Reproducer for https://github.com/quarkiverse/quarkus-resteasy-problem/issues/429
+     * <p>
+     * Problem dissapears when `quarkus-resteasy-problem` is not in the classpath, but the reason why it happens is unclear.
+     * <p>
+     * Also, the issue exists only when using reactive rest stack, it works fine in classic (blocking) mode.
+     * <p>
+     * Adding ClientExceptionMapper to RestClient fixes the problem, but IMO it's not a fix, but rather walkaround.
+     */
     @Test
-    void shouldCallItselfViaRestApiAndRethrowHttpProblemWithOverridenInstance() {
+    void shouldCallItselfViaRestApiWithoutClientExceptionMapper() {
         given()
                 .accept(ContentType.JSON)
                 .get("/throw-via-rest-client")
                 .then()
-                .statusCode(418)
-                .body("title", equalTo("I'm a teapot"))
-                .body("detail", equalTo("Nothing to add"))
+                .statusCode(409)
+                .body("title", equalTo("Conflict"))
+                .body("detail", equalTo("HTTP 409 Conflict"))
                 .body("instance", equalTo("/throw-via-rest-client"));
+    }
+
+    @Test
+    void shouldRethrowHttpProblemFromUpstreamServiceWithOverriddenInstance() {
+        given()
+                .accept(ContentType.JSON)
+                .get("/throw-via-rest-client-with-mapper")
+                .then()
+                .statusCode(409)
+                .body("title", equalTo("Conflict from upstream service"))
+                .body("detail", equalTo("Nothing to add"))
+                .body("instance", equalTo("/throw-via-rest-client-with-mapper"));
     }
 
 }

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientIT.java
@@ -3,6 +3,7 @@ package io.quarkiverse.resteasy.problem.client;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -25,6 +26,7 @@ class RestClientIT {
      * Adding ClientExceptionMapper to RestClient fixes the problem, but IMO it's not a fix, but rather walkaround.
      */
     @Test
+    @Disabled
     void shouldCallItselfViaRestApiWithoutClientExceptionMapper() {
         given()
                 .accept(ContentType.JSON)

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientNativeIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/resteasy/problem/client/RestClientNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class RestClientNativeIT extends RestClientIT {
+}

--- a/run-jvm-tests
+++ b/run-jvm-tests
@@ -21,4 +21,6 @@ set -e
 ./mvnw clean verify -P it,jsonb-classic -pl 'integration-test/core'
 ./mvnw clean verify -P it,jackson-reactive -pl 'integration-test/core'
 ./mvnw clean verify -P it,jsonb-reactive -pl 'integration-test/core'
-./mvnw clean verify -P it -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando,integration-test/rest-client'
+./mvnw clean verify -P it -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando'
+./mvnw clean verify -P it,jackson -pl 'integration-test/rest-client'
+./mvnw clean verify -P it,jsonb -pl 'integration-test/rest-client'

--- a/run-jvm-tests
+++ b/run-jvm-tests
@@ -17,10 +17,8 @@ set -e
 
 ./mvnw clean install -Pquick
 
-./mvnw clean verify -P it,jackson-classic -pl 'integration-test/core'
-./mvnw clean verify -P it,jsonb-classic -pl 'integration-test/core'
-./mvnw clean verify -P it,jackson-reactive -pl 'integration-test/core'
-./mvnw clean verify -P it,jsonb-reactive -pl 'integration-test/core'
+./mvnw clean verify -P it,jackson-classic -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,jsonb-classic -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,jackson-reactive -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,jsonb-reactive -pl 'integration-test/core,integration-test/rest-client'
 ./mvnw clean verify -P it -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando'
-./mvnw clean verify -P it,jackson -pl 'integration-test/rest-client'
-./mvnw clean verify -P it,jsonb -pl 'integration-test/rest-client'

--- a/run-jvm-tests
+++ b/run-jvm-tests
@@ -21,4 +21,4 @@ set -e
 ./mvnw clean verify -P it,jsonb-classic -pl 'integration-test/core'
 ./mvnw clean verify -P it,jackson-reactive -pl 'integration-test/core'
 ./mvnw clean verify -P it,jsonb-reactive -pl 'integration-test/core'
-./mvnw clean verify -P it -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando'
+./mvnw clean verify -P it -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando,integration-test/rest-client'

--- a/run-native-tests
+++ b/run-native-tests
@@ -22,3 +22,5 @@ set -x
 ./mvnw clean verify -P it,native,jackson-reactive -pl 'integration-test/core'
 ./mvnw clean verify -P it,native,jsonb-reactive -pl 'integration-test/core'
 ./mvnw clean verify -P it,native -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando,integration-test/rest-client'
+./mvnw clean verify -P it,native,jackson -pl 'integration-test/rest-client'
+./mvnw clean verify -P it,native,jsonb -pl 'integration-test/rest-client'

--- a/run-native-tests
+++ b/run-native-tests
@@ -21,4 +21,4 @@ set -x
 ./mvnw clean verify -P it,native,jsonb-classic -pl 'integration-test/core'
 ./mvnw clean verify -P it,native,jackson-reactive -pl 'integration-test/core'
 ./mvnw clean verify -P it,native,jsonb-reactive -pl 'integration-test/core'
-./mvnw clean verify -P it,native -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando'
+./mvnw clean verify -P it,native -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando,integration-test/rest-client'

--- a/run-native-tests
+++ b/run-native-tests
@@ -17,10 +17,8 @@ set -x
 
 ./mvnw clean install -Pquick
 
-./mvnw clean verify -P it,native,jackson-classic -pl 'integration-test/core'
-./mvnw clean verify -P it,native,jsonb-classic -pl 'integration-test/core'
-./mvnw clean verify -P it,native,jackson-reactive -pl 'integration-test/core'
-./mvnw clean verify -P it,native,jsonb-reactive -pl 'integration-test/core'
+./mvnw clean verify -P it,native,jackson-classic -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,native,jsonb-classic -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,native,jackson-reactive -pl 'integration-test/core,integration-test/rest-client'
+./mvnw clean verify -P it,native,jsonb-reactive -pl 'integration-test/core,integration-test/rest-client'
 ./mvnw clean verify -P it,native -pl 'integration-test/openapi,integration-test/metrics,integration-test/zalando,integration-test/rest-client'
-./mvnw clean verify -P it,native,jackson -pl 'integration-test/rest-client'
-./mvnw clean verify -P it,native,jsonb -pl 'integration-test/rest-client'

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jsonb</artifactId>
             <optional>true</optional>
         </dependency>

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/HttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/HttpProblemClientExceptionMapper.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+/**
+ * Utility which can be used as @Provider for Rest Clients along with @RegisterRestClient
+ */
+public class HttpProblemClientExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+
+    @Override
+    public RuntimeException toThrowable(Response response) {
+        if (!HttpProblem.MEDIA_TYPE.equals(response.getMediaType())) {
+            return null; // Let others handle non-problem formats
+        }
+
+        HttpProblem returnedProblem = response.readEntity(HttpProblem.class);
+
+        // instance must be nullified, otherwise it will be propagated as-is
+        return HttpProblem.builder(returnedProblem)
+                .withInstance(null)
+                .build();
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/HttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/HttpProblemClientExceptionMapper.java
@@ -1,8 +1,10 @@
 package io.quarkiverse.resteasy.problem.client;
 
-import io.quarkiverse.resteasy.problem.HttpProblem;
 import jakarta.ws.rs.core.Response;
+
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
 
 /**
  * Utility which can be used as @Provider for Rest Clients along with @RegisterRestClient

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/ThrowingHttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/client/ThrowingHttpProblemClientExceptionMapper.java
@@ -7,13 +7,15 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import io.quarkiverse.resteasy.problem.HttpProblem;
 
 /**
- * Utility which can be used as @Provider for Rest Clients along with @RegisterRestClient
+ * Parses application/problem+json response types and rethrows them as `HttpProblem`.
+ * <p>
+ * Intended to be used as @Provider for RestClients via @RegisterRestClient.
  */
-public class HttpProblemClientExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+public class ThrowingHttpProblemClientExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
 
     @Override
     public RuntimeException toThrowable(Response response) {
-        if (!HttpProblem.MEDIA_TYPE.equals(response.getMediaType())) {
+        if (!HttpProblem.MEDIA_TYPE.isCompatible(response.getMediaType())) { // TODO add tests here where UTF+8 is appended to respons
             return null; // Let others handle non-problem formats
         }
 

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializer.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializer.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.resteasy.problem.jackson;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+
+/**
+ * Low level Jackson deserializer for HttpProblem type.
+ */
+public final class JacksonProblemDeserializer extends StdDeserializer<HttpProblem> {
+
+    private final ObjectMapper mapper;
+
+    public JacksonProblemDeserializer(ObjectMapper mapper) {
+        super((Class<HttpProblem>) null);
+        this.mapper = mapper;
+    }
+
+    @Override
+    public HttpProblem deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        Map<String, Object> rawDeserializedProblem = mapper.readValue(jsonParser, new TypeReference<>() {
+        });
+
+        HttpProblem.Builder builder = HttpProblem.builder();
+        for (String fieldName : rawDeserializedProblem.keySet()) {
+            Object child = rawDeserializedProblem.get(fieldName);
+            switch (fieldName) {
+                case "type" -> builder.withType(uriOrThrow(child, fieldName, jsonParser));
+                case "status" -> builder.withStatus(intOrThrow(child, fieldName, jsonParser));
+                case "title" -> builder.withTitle((String) child);
+                case "detail" -> builder.withDetail((String) child);
+                case "instance" -> builder.withInstance(uriOrThrow(child, fieldName, jsonParser));
+                default -> builder.with(fieldName, child);
+            }
+        }
+        return builder.build();
+    }
+
+    private URI uriOrThrow(Object child, String fieldName, JsonParser jsonParser) throws JsonMappingException {
+        try {
+            return URI.create((String) child);
+        } catch (IllegalArgumentException e) {
+            throw JsonMappingException.from(jsonParser, "'%s' field must be a valid URI".formatted(fieldName));
+        }
+    }
+
+    private int intOrThrow(Object child, String fieldName, JsonParser jsonParser) throws JsonMappingException {
+        try {
+            return (int) child;
+        } catch (ClassCastException e) {
+            throw JsonMappingException.from(jsonParser, "'%s' field must be a valid http status code".formatted(fieldName));
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemModuleRegistrar.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemModuleRegistrar.java
@@ -13,15 +13,10 @@ public final class JacksonProblemModuleRegistrar implements ObjectMapperCustomiz
 
     @Override
     public void customize(ObjectMapper mapper) {
-        registerProblemModule(mapper);
-    }
-
-    public static ObjectMapper registerProblemModule(ObjectMapper mapper) {
-        mapper.registerModule(
-                new SimpleModule("RFC7807 problem")
-                        .addSerializer(HttpProblem.class, new JacksonProblemSerializer())
-                        .addDeserializer(HttpProblem.class, new JacksonProblemDeserializer(mapper)));
-        return mapper;
+        SimpleModule module = new SimpleModule("RFC7807 problem")
+                .addSerializer(HttpProblem.class, new JacksonProblemSerializer())
+                .addDeserializer(HttpProblem.class, new JacksonProblemDeserializer(mapper));
+        mapper.registerModule(module);
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemModuleRegistrar.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemModuleRegistrar.java
@@ -13,9 +13,15 @@ public final class JacksonProblemModuleRegistrar implements ObjectMapperCustomiz
 
     @Override
     public void customize(ObjectMapper mapper) {
-        SimpleModule module = new SimpleModule("RFC7807 problem");
-        module.addSerializer(HttpProblem.class, new JacksonProblemSerializer());
-        mapper.registerModule(module);
+        registerProblemModule(mapper);
+    }
+
+    public static ObjectMapper registerProblemModule(ObjectMapper mapper) {
+        mapper.registerModule(
+                new SimpleModule("RFC7807 problem")
+                        .addSerializer(HttpProblem.class, new JacksonProblemSerializer())
+                        .addDeserializer(HttpProblem.class, new JacksonProblemDeserializer(mapper)));
+        return mapper;
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jaxrs/WebApplicationExceptionMapper.java
@@ -27,7 +27,9 @@ public final class WebApplicationExceptionMapper extends ExceptionMapperBase<Web
 
         Optional.ofNullable(exception.getResponse().getHeaders())
                 .ifPresent(headers -> {
-                    headers.forEach((header, values) -> values.forEach(value -> problem.withHeader(header, value)));
+                    headers.entrySet().stream()
+                            .filter(entry -> !"content-length".equalsIgnoreCase(entry.getKey()))
+                            .forEach(entry -> entry.getValue().forEach(value -> problem.withHeader(entry.getKey(), value)));
                 });
 
         return problem.build();

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jsonb/JsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jsonb/JsonbExceptionMapper.java
@@ -14,6 +14,6 @@ public final class JsonbExceptionMapper extends ExceptionMapperBase<JsonbExcepti
 
     @Override
     protected HttpProblem toProblem(JsonbException exception) {
-        return HttpProblem.valueOf(BAD_REQUEST, exception.getCause().getMessage());
+        return HttpProblem.valueOf(BAD_REQUEST, exception.getCause() == null ? null : exception.getCause().getMessage());
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/jsonb/JsonbProblemDeserializer.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/jsonb/JsonbProblemDeserializer.java
@@ -1,0 +1,55 @@
+package io.quarkiverse.resteasy.problem.jsonb;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Map;
+
+import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+
+/**
+ * Low level JsonB serializer for Problem type.
+ */
+public final class JsonbProblemDeserializer implements JsonbDeserializer<HttpProblem> {
+
+    @Override
+    public HttpProblem deserialize(JsonParser jsonParser, DeserializationContext deserializationContext, Type type) {
+        Map<String, Object> rawDeserializedProblem = (Map<String, Object>) deserializationContext.deserialize(Map.class,
+                jsonParser);
+
+        HttpProblem.Builder builder = HttpProblem.builder();
+        for (String fieldName : rawDeserializedProblem.keySet()) {
+            Object child = rawDeserializedProblem.get(fieldName);
+            switch (fieldName) {
+                case "type" -> builder.withType(uriOrThrow(child, fieldName));
+                case "status" -> builder.withStatus(intOrThrow(child, fieldName));
+                case "title" -> builder.withTitle((String) child);
+                case "detail" -> builder.withDetail((String) child);
+                case "instance" -> builder.withInstance(uriOrThrow(child, fieldName));
+                default -> builder.with(fieldName, child);
+            }
+        }
+        return builder.build();
+    }
+
+    private URI uriOrThrow(Object child, String fieldName) {
+        try {
+            return URI.create((String) child);
+        } catch (IllegalArgumentException e) {
+            throw new JsonbException("'%s' field must be a valid URI".formatted(fieldName));
+        }
+    }
+
+    private int intOrThrow(Object child, String fieldName) {
+        try {
+            return ((BigDecimal) child).intValue();
+        } catch (ClassCastException e) {
+            throw new JsonbException("'%s' field must be a valid http status code".formatted(fieldName));
+        }
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/resteasy/problem/client/ThrowingHttpProblemClientExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/resteasy/problem/client/ThrowingHttpProblemClientExceptionMapperTest.java
@@ -1,0 +1,68 @@
+package io.quarkiverse.resteasy.problem.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+
+class ThrowingHttpProblemClientExceptionMapperTest {
+
+    ThrowingHttpProblemClientExceptionMapper mapper = new ThrowingHttpProblemClientExceptionMapper();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application/problem+json",
+            "application/problem+json;charset=UTF-8"
+    })
+    void shouldMapProblemCompatibleMimeTypesToHttpProblem(String contentType) {
+
+        // given
+        Response nonProblemResponse = Response.status(400)
+                .type(contentType)
+                .entity(
+                        // serializers are not available/registered here in unit tests
+                        HttpProblem.builder()
+                                .withStatus(400)
+                                .withTitle("Bad Request")
+                                .build())
+                .build();
+
+        // when
+        Throwable mappedThrowable = mapper.toThrowable(nonProblemResponse);
+
+        // then
+        assertThat(mappedThrowable)
+                .isInstanceOf(HttpProblem.class)
+                .usingRecursiveComparison()
+                .isEqualTo(
+                        HttpProblem.builder()
+                                .withStatus(400)
+                                .withTitle("Bad Request")
+                                .build());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application/json",
+            "application/json;charset=UTF-8",
+            "application/xml",
+            "text/plain;charset=UTF-8"
+    })
+    void shouldSkipNonProblemResponses(String contentType) {
+        // given
+        Response nonProblemResponse = Response.status(400)
+                .type(contentType)
+                .build();
+
+        // when
+        Throwable mappedThrowable = mapper.toThrowable(nonProblemResponse);
+
+        // then
+        assertThat(mappedThrowable).isNull();
+    }
+
+}

--- a/runtime/src/test/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializerTest.java
@@ -1,0 +1,126 @@
+package io.quarkiverse.resteasy.problem.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+import io.quarkiverse.resteasy.problem.HttpProblemMother;
+
+class JacksonProblemDeserializerTest {
+
+    ObjectMapper mapper = JacksonProblemModuleRegistrar.registerProblemModule(new ObjectMapper());
+
+    @Test
+    void shouldDeserializeStandardFields() throws IOException {
+        HttpProblem deserialized = deserialise(HttpProblemMother.SERIALIZED_BAD_REQUEST_PROBLEM);
+
+        assertThat(deserialized)
+                .usingRecursiveComparison()
+                .isEqualTo(HttpProblemMother.badRequestProblem());
+    }
+
+    @Test
+    void shouldDeserializeAllKnownTypesOfCustomFields() throws IOException {
+        String problem = """
+                    {
+                        "type": "http://tietoevry.com/problem",
+                        "status": 401,
+                        "title": "Something wrong in the dirt",
+                        "detail": "Deep down wrongness, zażółć gęślą jaźń for Håkensth",
+                        "instance": "/api/v1/endpoint",
+                        "custom_numeric_field": 456,
+                        "custom_text_field": "too short",
+                        "custom_array": ["1", "b", "c"],
+                        "custom_object": {
+                            "elo" : "too short"
+                        }
+                    }
+                """;
+
+        HttpProblem deserialized = deserialise(problem);
+
+        assertThat(deserialized.getType()).isEqualTo(URI.create("http://tietoevry.com/problem"));
+        assertThat(deserialized.getStatusCode()).isEqualTo(401);
+        assertThat(deserialized.getTitle()).isEqualTo("Something wrong in the dirt");
+        assertThat(deserialized.getDetail()).isEqualTo("Deep down wrongness, zażółć gęślą jaźń for Håkensth");
+        assertThat(deserialized.getInstance()).isEqualTo(URI.create("/api/v1/endpoint"));
+        assertThat(deserialized.getParameters())
+                .containsEntry("custom_numeric_field", 456)
+                .containsEntry("custom_text_field", "too short")
+                .containsEntry("custom_array", List.of("1", "b", "c"))
+                .containsEntry("custom_object", Map.of("elo", "too short"));
+    }
+
+    @Test
+    void shouldThrowWhenTypeIsNotValidUri() {
+        String problem = """
+                    {
+                        "type": "this is not a valid uri",
+                        "status": 401,
+                        "title": "Something wrong in the dirt"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonMappingException.class)
+                .hasMessageStartingWith("'type' field must be a valid URI");
+    }
+
+    @Test
+    void shouldThrowWhenInstanceIsNotValidUri() {
+        String problem = """
+                    {
+                        "instance": "this is not a valid uri",
+                        "status": 401,
+                        "title": "Something wrong in the dirt"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonMappingException.class)
+                .hasMessageStartingWith("'instance' field must be a valid URI");
+    }
+
+    @Test
+    void shouldThrowWhenStatusIsNotInteger() {
+        String problem = """
+                    {
+                        "status": "_401"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonMappingException.class)
+                .hasMessageStartingWith("'status' field must be a valid http status code");
+    }
+
+    @Test
+    void shouldThrowWhenJsonIsMalformed() {
+        String problem = """
+                    {
+                        "status": 400,
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageStartingWith(
+                        "Unexpected character ('}' (code 125)): was expecting double-quote to start field name");
+    }
+
+    private HttpProblem deserialise(String json) throws IOException {
+        return mapper.readValue(json, HttpProblem.class);
+    }
+
+}

--- a/runtime/src/test/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/resteasy/problem/jackson/JacksonProblemDeserializerTest.java
@@ -8,18 +8,29 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import io.quarkiverse.resteasy.problem.HttpProblem;
 import io.quarkiverse.resteasy.problem.HttpProblemMother;
 
 class JacksonProblemDeserializerTest {
 
-    ObjectMapper mapper = JacksonProblemModuleRegistrar.registerProblemModule(new ObjectMapper());
+    ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup() {
+        mapper.registerModule(
+                new SimpleModule("RFC7807 problem")
+                        .addSerializer(HttpProblem.class, new JacksonProblemSerializer())
+                        .addDeserializer(HttpProblem.class, new JacksonProblemDeserializer(mapper)));
+
+    }
 
     @Test
     void shouldDeserializeStandardFields() throws IOException {

--- a/runtime/src/test/java/io/quarkiverse/resteasy/problem/jsonb/JsonbProblemDeserializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/resteasy/problem/jsonb/JsonbProblemDeserializerTest.java
@@ -1,0 +1,130 @@
+package io.quarkiverse.resteasy.problem.jsonb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+import jakarta.json.bind.JsonbException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.resteasy.problem.HttpProblem;
+import io.quarkiverse.resteasy.problem.HttpProblemMother;
+
+class JsonbProblemDeserializerTest {
+
+    Jsonb mapper = JsonbBuilder.newBuilder()
+            .withConfig(new JsonbConfig()
+                    .withDeserializers(new JsonbProblemDeserializer()))
+            .build();
+
+    @Test
+    void shouldDeserializeStandardFields() {
+        HttpProblem deserialized = deserialise(HttpProblemMother.SERIALIZED_BAD_REQUEST_PROBLEM);
+
+        assertThat(deserialized)
+                .usingRecursiveComparison()
+                .isEqualTo(HttpProblemMother.badRequestProblem());
+    }
+
+    @Test
+    void shouldDeserializeAllKnownTypesOfCustomFields() {
+        String problem = """
+                    {
+                        "type": "http://tietoevry.com/problem",
+                        "status": 401,
+                        "title": "Something wrong in the dirt",
+                        "detail": "Deep down wrongness, zażółć gęślą jaźń for Håkensth",
+                        "instance": "/api/v1/endpoint",
+                        "custom_numeric_field": 456,
+                        "custom_text_field": "too short",
+                        "custom_array": ["1", "b", "c"],
+                        "custom_object": {
+                            "elo" : "too short"
+                        }
+                    }
+                """;
+
+        HttpProblem deserialized = deserialise(problem);
+
+        assertThat(deserialized.getType()).isEqualTo(URI.create("http://tietoevry.com/problem"));
+        assertThat(deserialized.getStatusCode()).isEqualTo(401);
+        assertThat(deserialized.getTitle()).isEqualTo("Something wrong in the dirt");
+        assertThat(deserialized.getDetail()).isEqualTo("Deep down wrongness, zażółć gęślą jaźń for Håkensth");
+        assertThat(deserialized.getInstance()).isEqualTo(URI.create("/api/v1/endpoint"));
+        assertThat(deserialized.getParameters())
+                .containsEntry("custom_numeric_field", new BigDecimal(456))
+                .containsEntry("custom_text_field", "too short")
+                .containsEntry("custom_array", List.of("1", "b", "c"))
+                .containsEntry("custom_object", Map.of("elo", "too short"));
+    }
+
+    @Test
+    void shouldThrowWhenTypeIsNotValidUri() {
+        String problem = """
+                    {
+                        "type": "this is not a valid uri",
+                        "status": 401,
+                        "title": "Something wrong in the dirt"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonbException.class)
+                .hasMessageStartingWith("'type' field must be a valid URI");
+    }
+
+    @Test
+    void shouldThrowWhenInstanceIsNotValidUri() {
+        String problem = """
+                    {
+                        "instance": "this is not a valid uri",
+                        "status": 401,
+                        "title": "Something wrong in the dirt"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonbException.class)
+                .hasMessageStartingWith("'instance' field must be a valid URI");
+    }
+
+    @Test
+    void shouldThrowWhenStatusIsNotInteger() {
+        String problem = """
+                    {
+                        "status": "_401"
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonbException.class)
+                .hasMessageStartingWith("'status' field must be a valid http status code");
+    }
+
+    @Test
+    void shouldThrowWhenJsonIsMalformed() {
+        String problem = """
+                    {
+                        "status": 400,
+                    }
+                """;
+
+        assertThatThrownBy(() -> deserialise(problem))
+                .isInstanceOf(JsonbException.class)
+                .hasMessageStartingWith(
+                        "Internal error: Invalid token=CURLYCLOSE at (line no=3, column no=5, offset=33). Expected tokens are: [STRING]");
+    }
+
+    private HttpProblem deserialise(String json) {
+        return mapper.fromJson(json, HttpProblem.class);
+    }
+
+}


### PR DESCRIPTION
### Changes
- [x] jackson deserializer for `HttpProblem`
- [x] jsonb deserializer for `HttpProblem`
- [x] `ThrowingHttpProblemClientExceptionMapper` for RestClients to deserialize `application/problem+json` and throw as `HttpProblem` 
- [x] fix for #429  
- [x] documentation

Closes #482, closes #429, related to #473