### PR TITLE
fix #524: trailing dot in constraint violation paths

### DIFF
--- a/integration-test/core/src/main/java/io/quarkiverse/resteasy/problem/ValidationExceptionsResource.java
+++ b/integration-test/core/src/main/java/io/quarkiverse/resteasy/problem/ValidationExceptionsResource.java
@@ -1,10 +1,19 @@
 package io.quarkiverse.resteasy.problem;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import jakarta.inject.Inject;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Payload;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import jakarta.validation.Validator;
@@ -138,32 +147,31 @@ public class ValidationExceptionsResource {
       public String code;
     }
 
-    @jakarta.validation.Constraint(validatedBy = CustomNameValidator.class)
-    @java.lang.annotation.Target({ java.lang.annotation.ElementType.TYPE })
-    @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-    public static @interface ValidCustomName {
+    @Constraint(validatedBy = CustomNameValidator.class)
+    @Target({ ElementType.TYPE })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ValidCustomName {
       String message() default "must match regex";
 
       Class<?>[] groups() default {};
 
-      Class<? extends jakarta.validation.Payload>[] payload() default {};
+      Class<? extends Payload>[] payload() default {};
     }
 
-    public static class CustomNameValidator implements jakarta.validation.ConstraintValidator<ValidCustomName, CustomName> {
-      private java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("^[A-Z]{4}0[0-9]{6}$");
+    public static class CustomNameValidator implements ConstraintValidator<ValidCustomName, CustomName> {
+      private final Pattern pattern = Pattern.compile("^[A-Z]{4}0[0-9]{6}$");
 
       @Override
-      public boolean isValid(CustomName customName, jakarta.validation.ConstraintValidatorContext constraintValidatorContext) {
-        boolean isValid = true;
+      public boolean isValid(CustomName customName, ConstraintValidatorContext constraintValidatorContext) {
         String code = customName.code;
         constraintValidatorContext.disableDefaultConstraintViolation();
 
         if (pattern != null && !pattern.matcher(code).matches()) {
           constraintValidatorContext.buildConstraintViolationWithTemplate("must match \"" + pattern.pattern() + "\"")
               .addConstraintViolation();
-          isValid = false;
+          return false;
         }
-        return isValid;
+        return true;
       }
 }
 

--- a/integration-test/core/src/main/java/io/quarkiverse/resteasy/problem/ValidationExceptionsResource.java
+++ b/integration-test/core/src/main/java/io/quarkiverse/resteasy/problem/ValidationExceptionsResource.java
@@ -163,10 +163,9 @@ public class ValidationExceptionsResource {
 
       @Override
       public boolean isValid(CustomName customName, ConstraintValidatorContext constraintValidatorContext) {
-        String code = customName.code;
         constraintValidatorContext.disableDefaultConstraintViolation();
 
-        if (pattern != null && !pattern.matcher(code).matches()) {
+        if (!pattern.matcher(customName.code).matches()) {
           constraintValidatorContext.buildConstraintViolationWithTemplate("must match \"" + pattern.pattern() + "\"")
               .addConstraintViolation();
           return false;

--- a/integration-test/core/src/test/java/io/quarkiverse/resteasy/problem/ValidationMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/resteasy/problem/ValidationMappersIT.java
@@ -152,4 +152,21 @@ class ValidationMappersIT {
                 .body("violations.find{it.field == 'age'}.message", equalTo("must be greater than or equal to 18"));
     }
 
+    @Test
+    void shouldNotIncludeTrailingDotInCustomValidationConstraintViolationPaths() {
+        given()
+                .body("{\"name\": {\"code\": \"INVALID_CODE\"}}")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/validation/constraint-violation-exception/custom-validation")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("title", equalTo(BAD_REQUEST.getReasonPhrase()))
+                .body("status", equalTo(BAD_REQUEST.getStatusCode()))
+                .body("violations", hasSize(1))
+                .body("violations[0].field", equalTo("name"))
+                .body("violations[0].in", equalTo("body"))
+                .body("violations[0].message", equalTo("must match \"^[A-Z]{4}0[0-9]{6}$\""))
+                .body("stacktrace", nullValue());
+    }
+
 }

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
@@ -142,7 +142,7 @@ public final class ConstraintViolationExceptionMapper extends ExceptionMapperBas
                 segmentIterator.next();
             } else {
                 String segment = segmentIterator.next().toString();
-                if (segment != null && !segment.trim().isEmpty()) {
+                if (!segment.isBlank()) {
                     pathSegments.add(segment);
                 }
             }

--- a/runtime/src/main/java/io/quarkiverse/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/resteasy/problem/validation/ConstraintViolationExceptionMapper.java
@@ -141,7 +141,10 @@ public final class ConstraintViolationExceptionMapper extends ExceptionMapperBas
                 skipFirstSegments -= 1;
                 segmentIterator.next();
             } else {
-                pathSegments.add(segmentIterator.next().toString());
+                String segment = segmentIterator.next().toString();
+                if (segment != null && !segment.trim().isEmpty()) {
+                    pathSegments.add(segment);
+                }
             }
         }
         return String.join(".", pathSegments);


### PR DESCRIPTION
As per this [discussion](https://github.com/quarkiverse/quarkus-resteasy-problem/discussions/519) I have raise the PR. I have updated ConstraintViolationExceptionMapper to skip null or empty path segments when building the property path. This was added to avoid trailing dot in constraint violation paths for value objects.