### PR TITLE
docs(readme): refresh docs to reflect http-problem rename

### DIFF
--- a/MIGRATION-FROM-RESTEASY-PROBLEM.md
+++ b/MIGRATION-FROM-RESTEASY-PROBLEM.md
@@ -1,0 +1,63 @@
+# Migration from `quarkus-resteasy-problem`
+
+The extension was renamed to reflect support for both RESTEasy Classic and Quarkus REST (formerly RESTEasy Reactive). Apply the following changes when moving from `io.quarkiverse.resteasy-problem:quarkus-resteasy-problem` (3.32.x or earlier) to `io.quarkiverse.httpproblem:quarkus-http-problem` (3.33.0 onward; on Central this may be **3.33.0.CR1** until a GA build is published).
+
+If you only consumed the extension transitively and have no custom imports or `quarkus.resteasy.problem.*` configuration, replacing the dependency coordinates may be enough.
+
+See [README.md — Versioning](README.md#versioning) for which extension release matches your Quarkus version.
+
+## Dependency coordinates
+
+### Maven
+
+Replace the dependency coordinates:
+
+```xml
+<dependency>
+    <groupId>io.quarkiverse.httpproblem</groupId>
+    <artifactId>quarkus-http-problem</artifactId>
+    <version>3.33.0.CR1</version>
+</dependency>
+```
+
+Use a version compatible with your Quarkus release (see the [versioning table](README.md#versioning)).
+
+Remove `io.quarkiverse.resteasy-problem:quarkus-resteasy-problem`.
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+implementation("io.quarkiverse.httpproblem:quarkus-http-problem:3.33.0.CR1")
+```
+
+## Configuration
+
+### All settings are build-time
+
+Every `quarkus.http-problem.*` configuration key is now fixed at build time. After changing values in `application.properties` or `application.yaml`, rebuild packaged applications; in `quarkus:dev`, hot reload applies the change automatically.
+
+### Update property prefix
+
+Rename the configuration root only: `quarkus.resteasy.problem` → `quarkus.http-problem`. All keys under the old prefix move in parallel; for example:
+
+```properties
+quarkus.resteasy.problem.include-mdc-properties=uuid,traceId
+```
+
+becomes:
+
+```properties
+quarkus.http-problem.include-mdc-properties=uuid,traceId
+```
+
+Unrelated to the `quarkus.http-problem.*` keys above: problem summaries still use Quarkus’s usual logging mechanism, under the SLF4J category `http-problem`. If you set something like `quarkus.log.category.http-problem.level`, keep it as-is when migrating—that category name did not change in recent `quarkus-resteasy-problem` releases either.
+
+## Update Java imports
+
+If you import any class from this extension, change the package from `io.quarkiverse.resteasy.problem` to `io.quarkiverse.httpproblem`. For example:
+
+```java
+import io.quarkiverse.resteasy.problem.HttpProblem;
+// becomes
+import io.quarkiverse.httpproblem.HttpProblem;
+```

--- a/README.md
+++ b/README.md
@@ -1,54 +1,57 @@
-# Problem Details for HTTP APIs (RFC-7807) implementation for Quarkus REST / RESTEasy.
+# Problem Details for HTTP APIs ([RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457)) for Quarkus REST / RESTEasy
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/quarkiverse/quarkus-http-problem/blob/main/LICENSE.txt)
-[![Documentation](https://img.shields.io/badge/docs-quarkus.io-0A6EBD)](https://quarkus.io/extensions/io.quarkiverse.httpproblem/quarkus-http-problem/)
+[License](https://github.com/quarkiverse/quarkus-http-problem/blob/main/LICENSE.txt)
+[Documentation](https://quarkus.io/extensions/io.quarkiverse.httpproblem/quarkus-http-problem/)
 
-[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml)
-[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml)
-[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml)
+[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml)
+[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml)
+[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml)
 
-[RFC7807 Problem](https://tools.ietf.org/html/rfc7807) extension for Quarkus Rest applications. It maps Exceptions to `application/problem+json` HTTP responses. Inspired by [Zalando Problem library](https://github.com/zalando/problem), originally open sourced by [Tietoevry](https://github.com/evry), now part of Quarkiverse.
+Extension implementing **Problem Details for HTTP APIs** as defined in [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (which [obsoletes RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807); the wire format and media type remain the same for typical JSON usage). It maps exceptions to `application/problem+json` HTTP responses. Inspired by the [Zalando Problem library](https://github.com/zalando/problem), originally open sourced by [Tieto](https://github.com/tieto), now part of Quarkiverse.
 
 This extension supports:
+
 - `quarkus-rest-jackson` and `quarkus-rest-jsonb` (reactive and blocking)
 - `quarkus-resteasy-jackson` and `quarkus-resteasy-jsonb` (classic blocking)
 - OpenAPI integration (via `quarkus-smallrye-openapi`)
 - JVM and native mode
 
 ## Why you should use this extension?
-- __consistency__ - it unifies your REST API error messages, and gives it much needed consistency, no matter which JSON provider (Jackson vs JsonB) or paradigm (classic/blocking vs reactive) you're using.   
 
-- __predictability__ - no matter what kind of exception is thrown: expected (thrown by you on purpose), or unexpected (not thrown 'by design') - your API consumer gets similar, repeatable experience.  
-
-- __safety__ - it helps prevent leakage of some implementation details like stack-traces, DTO/resource class names etc.
-
-- __time-saving__ - in most cases you will not have to implement your own JaxRS `ExceptionMapper`s anymore, which makes your app smaller, and less error-prone. 
+- **consistency** - it unifies your REST API error messages, and gives it much needed consistency, no matter which JSON provider (Jackson vs JsonB) or paradigm (classic/blocking vs reactive) you're using.   
+- **predictability** - no matter what kind of exception is thrown: expected (thrown by you on purpose), or unexpected (not thrown 'by design') - your API consumer gets similar, repeatable experience.  
+- **safety** - it helps prevent leakage of some implementation details like stack-traces, DTO/resource class names etc.
+- **time-saving** - in most cases you will not have to implement your own JaxRS `ExceptionMapper`s anymore, which makes your app smaller, and less error-prone.
 
 See [Built-in Exception Mappers Wiki](https://github.com/quarkiverse/quarkus-http-problem/wiki#built-in-exception-mappers) for more details.
 
-From [RFC7807](https://tools.ietf.org/html/rfc7807):
-```
-HTTP [RFC7230] status codes are sometimes not sufficient to convey
-enough information about an error to be helpful.  While humans behind
-Web browsers can be informed about the nature of the problem with an
-HTML [W3C.REC-html5-20141028] response body, non-human consumers of
-so-called "HTTP APIs" are usually not.
-```
+From [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (abstract):
 
-## Usage
-### Quarkus 3.14+
-Add this to your pom.xml:
+> This document defines a "problem detail" to carry machine-readable details of errors in HTTP response content to avoid the need to define new error response formats for HTTP APIs.
+
+The introduction adds that HTTP status codes cannot always convey enough information about errors to be helpful, and that non-human consumers of HTTP APIs have difficulty interpreting HTML responses—hence a common JSON (and optional XML) format for problem details. See [Appendix D of RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457#appendix-D) for a list of changes from [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807).
+
+## Getting started
+
+Use `[io.quarkiverse.httpproblem:quarkus-http-problem](https://central.sonatype.com/artifact/io.quarkiverse.httpproblem/quarkus-http-problem)` with **Quarkus 3.32 or newer** (same baseline as the extension version you choose). Older Quarkus releases should keep using `[quarkus-resteasy-problem](#quarkus-resteasy-problem-legacy-coordinates)` until you upgrade.
+
+Add this to your pom.xml (this extension is not on the Quarkus Platform BOM yet, so the version must be explicit):
+
 ```xml
 <dependency>
     <groupId>io.quarkiverse.httpproblem</groupId>
     <artifactId>quarkus-http-problem</artifactId>
+    <version>3.33.0.CR1</version>
 </dependency>
 ```
 
-Once you run Quarkus: `./mvnw compile quarkus:dev`, and you will find `http-problem` in the logs:
-<pre>
-Installed features: [cdi, <b><u>http-problem</u></b>, rest-jackson, ...]
-</pre>
+Pick a version that matches your Quarkus release; see [Versioning](#versioning) below.
+
+Once you run Quarkus: `./mvnw compile quarkus:dev`, you should see `http-problem` in the logs:
+
+```
+Installed features: [cdi, http-problem, rest-jackson, ...]
+```
 
 Now you can throw `HttpProblem`s (using builder or a subclass), JaxRS exceptions (e.g `NotFoundException`) or `ThrowableProblem`s from Zalando library:
 
@@ -65,18 +68,13 @@ public class HelloResource {
 
     @GET
     public String hello() {
-        throw new HelloProblem("rfc7807-by-example");
-    }
-
-    static class HelloProblem extends HttpProblem {
-        HelloProblem(String message) {
-            super(builder()
-                    .withTitle("Bad hello request")
-                    .withStatus(Response.Status.BAD_REQUEST)
-                    .withDetail(message)
-                    .withHeader("X-RFC7807-Message", message)
-                    .with("hello", "world"));
-        }
+        throw HttpProblem.builder()
+            .withTitle("Bad hello request")
+            .withStatus(Response.Status.BAD_REQUEST)
+            .withDetail("rfc9457-by-example")
+            .with("hello", "world")
+            .withHeader("X-Problem-Message", message)
+            .build();
     }
 }
 ```
@@ -85,27 +83,65 @@ Open [http://localhost:8080/hello](http://localhost:8080/hello) in your browser,
 
 ```json
 HTTP/1.1 400 Bad Request
-X-RFC7807-Message: rfc7807-by-example
+X-Problem-Message: rfc9457-by-example
 Content-Type: application/problem+json
         
 {
     "status": 400,
     "title": "Bad hello request",
-    "detail": "rfc7807-by-example",
+    "detail": "rfc9457-by-example",
     "instance": "/hello",
     "hello": "world"
 }
 ```
 
 This extension will also produce the following log message:
+
 ```
-10:53:48 INFO [http-problem] (executor-thread-1) status=400, title="Bad hello request", detail="rfc7807-by-example"
+10:53:48 INFO [http-problem] (executor-thread-1) status=400, title="Bad hello request", detail="rfc9457-by-example"
 ```
+
 Exceptions transformed into http 500s (aka server errors) will be logged as `ERROR`, including full stacktrace.
 
 More on throwing problems: [zalando/problem usage](https://github.com/zalando/problem#usage)
 
-## RestClients (available since <a href="https://github.com/quarkiverse/quarkus-http-problem/releases/tag/3.20.0">v3.20.0</a>)
+## Versioning
+
+### `quarkus-http-problem`
+
+Published as `[io.quarkiverse.httpproblem:quarkus-http-problem](https://central.sonatype.com/artifact/io.quarkiverse.httpproblem/quarkus-http-problem)`. This line targets **Quarkus 3.32+**; add the dependency and version from **Getting started**. 
+
+If you run an **older Quarkus**, stay on `**quarkus-resteasy-problem`** until you upgrade (table in the subsection below), or bump Quarkus first and then switch here.
+
+If you are upgrading from `io.quarkiverse.resteasy-problem`, see [Migration from](./MIGRATION-FROM-RESTEASY-PROBLEM.md) `quarkus-resteasy-problem`.
+
+### `quarkus-resteasy-problem` (legacy coordinates)
+
+New development continues only as `quarkus-http-problem` (same Git repository, new groupId, artifactId, and Java packages). The tables below pick the Quarkus line first, then the **latest** matching extension release on Central—use the linked version pages on Maven Central for older patch numbers if you must stay on an older line.
+
+`io.quarkiverse.resteasy-problem` (last release for this artifact: [3.32.1](https://central.sonatype.com/artifact/io.quarkiverse.resteasy-problem/quarkus-resteasy-problem/3.32.1)):
+
+
+| Quarkus version | Extension version                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| 3.32+           | [3.32.1](https://central.sonatype.com/artifact/io.quarkiverse.resteasy-problem/quarkus-resteasy-problem/3.32.1) |
+| 3.9+            | [3.21.1](https://central.sonatype.com/artifact/io.quarkiverse.resteasy-problem/quarkus-resteasy-problem/3.21.1) |
+
+
+`com.tietoevry.quarkus` (original vendor coordinates before the Quarkiverse move; last release: [3.9.0](https://central.sonatype.com/artifact/com.tietoevry.quarkus/quarkus-resteasy-problem/3.9.0)):
+
+
+| Quarkus version | Extension version                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| 3.9+            | [3.9.0](https://central.sonatype.com/artifact/com.tietoevry.quarkus/quarkus-resteasy-problem/3.9.0) |
+| 3.7.x – 3.8.x   | [3.7.0](https://central.sonatype.com/artifact/com.tietoevry.quarkus/quarkus-resteasy-problem/3.7.0) |
+| < 3.7           | [3.1.0](https://central.sonatype.com/artifact/com.tietoevry.quarkus/quarkus-resteasy-problem/3.1.0) |
+
+
+Quarkus **2.x** / **1.x** applications that still depend on `com.tietoevry.quarkus:quarkus-resteasy-problem` are not covered by `quarkus-http-problem`; upgrade Quarkus first, then switch to `[io.quarkiverse.httpproblem:quarkus-http-problem](https://central.sonatype.com/artifact/io.quarkiverse.httpproblem/quarkus-http-problem)` when you are on a supported Quarkus 3.x line.
+
+## RestClients (available since [v3.20.0](https://github.com/quarkiverse/quarkus-http-problem/releases/tag/3.20.0))
+
 If you use RestClients and your upstream services return `application/problem+json` responses, you can register `ThrowingHttpProblemClientExceptionMapper` for your client to get automatic deserialization and rethrowing `HttpProblem` instead of `ClientWebApplicationException` 
 
 ```java
@@ -118,27 +154,33 @@ public interface MyRestClient {
 }
 ```
 
-## OpenAPI integration (available since <a href="https://github.com/quarkiverse/quarkus-http-problem/releases/tag/3.20.0">v3.20.0</a>)
+## OpenAPI integration (available since [v3.20.0](https://github.com/quarkiverse/quarkus-http-problem/releases/tag/3.20.0))
+
 When `quarkus-smallrye-openapi` is in the classpath, this extension provides a bunch of out-of-the-box features :
 
 - complete OpenApi schema definitions for `HttpProblem` and `HttpValidationProblem` that can be used in annotations (e.g. `@Schema(implementation = HttpProblem.class)`)
 - auto-generating documentation for endpoints declaring `throws` for few common exceptions, e.g. `NotFoundException`,`ForbiddenException` or even `Exception`
+
 ```java
 @GET
 @Path("/my-endpoint")
 @APIResponse(responseCode = "409", description = "Request received but there has been a conflict")
 public void endpoint() throws NotFoundException {}
 ```
+
 this endpoint will automatically get both 409 (from `@APIResponse`) and 404 (derived from `throws`) responses documented in open api.
 
 - attaching `HttpProblem` schema to endpoints declaring error api responses (4XX and 5XX) without `content` field specified:
+
 ```java
 @APIResponse(
   responseCode = "409", 
   description = "Request received but there has been a conflict"
 )
 ```
+
 is an equivalent to this:
+
 ```java
 @APIResponse(
   responseCode = "409", 
@@ -165,7 +207,9 @@ public class MyHttpProblem extends HttpProblem {
 
 }
 ```
+
 and tell this extension which schema is default for Problem Details: 
+
 ```properties
 quarkus.http-problem.openapi.default-schema=MyHttpProblem
 ```
@@ -173,10 +217,13 @@ quarkus.http-problem.openapi.default-schema=MyHttpProblem
 ## Configuration options
 
 - (Build time) Include MDC properties in the API response. You have to provide those properties to MDC using `MDC.put`
+
 ```
 quarkus.http-problem.include-mdc-properties=uuid,application,version
 ```
+
 Result:
+
 ```json
 {
   "status": 500,
@@ -187,12 +234,15 @@ Result:
 }
 ```
 
-- (Runtime) Changes default `400 Bad request` response status when `ConstraintViolationException` is thrown (e.g. by Hibernate Validator)
+- (Build time) Changes default `400 Bad request` response status when `ConstraintViolationException` is thrown (e.g. by Hibernate Validator)
+
 ```
 quarkus.http-problem.constraint-violation.status=422
 quarkus.http-problem.constraint-violation.title=Constraint violation
 ```
+
 Result:
+
 ```json
 HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
@@ -205,6 +255,7 @@ Content-Type: application/problem+json
 ```
 
 - (Runtime) Tuning logging
+
 ```
 quarkus.log.category.http-problem.level=INFO # default: all problems are logged
 quarkus.log.category.http-problem.level=ERROR # only HTTP 5XX problems are logged
@@ -212,10 +263,12 @@ quarkus.log.category.http-problem.level=OFF # disables all problems-related logg
 ```
 
 ## Custom ProblemPostProcessor
+
 If you want to intercept, change or augment a mapped `HttpProblem` before it gets serialized into raw HTTP response 
 body, you can create a bean extending `ProblemPostProcessor`, and override `apply` method.
 
 Example:
+
 ```java
 @ApplicationScoped
 class CustomPostProcessor implements ProblemPostProcessor {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Problem Details for HTTP APIs ([RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457)) for Quarkus REST / RESTEasy
 
-[License](https://github.com/quarkiverse/quarkus-http-problem/blob/main/LICENSE.txt)
-[Documentation](https://quarkus.io/extensions/io.quarkiverse.httpproblem/quarkus-http-problem/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/quarkiverse/quarkus-http-problem/blob/main/LICENSE.txt)
+[![Documentation](https://img.shields.io/badge/docs-quarkus.io-0A6EBD)](https://quarkus.io/extensions/io.quarkiverse.httpproblem/quarkus-http-problem/)
 
-[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml)
-[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml)
-[Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml)
+[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/unit-tests.yaml)
+[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/integration-tests.yaml)
+[![Build status](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml/badge.svg)](https://github.com/quarkiverse/quarkus-http-problem/actions/workflows/native-mode-tests.yaml)
 
 Extension implementing **Problem Details for HTTP APIs** as defined in [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (which [obsoletes RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807); the wire format and media type remain the same for typical JSON usage). It maps exceptions to `application/problem+json` HTTP responses. Inspired by the [Zalando Problem library](https://github.com/zalando/problem), originally open sourced by [Tieto](https://github.com/tieto), now part of Quarkiverse.
 
@@ -16,20 +16,18 @@ This extension supports:
 - OpenAPI integration (via `quarkus-smallrye-openapi`)
 - JVM and native mode
 
-## Why you should use this extension?
+## Why use this extension?
+From [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457):
 
-- **consistency** - it unifies your REST API error messages, and gives it much needed consistency, no matter which JSON provider (Jackson vs JsonB) or paradigm (classic/blocking vs reactive) you're using.   
-- **predictability** - no matter what kind of exception is thrown: expected (thrown by you on purpose), or unexpected (not thrown 'by design') - your API consumer gets similar, repeatable experience.  
-- **safety** - it helps prevent leakage of some implementation details like stack-traces, DTO/resource class names etc.
-- **time-saving** - in most cases you will not have to implement your own JaxRS `ExceptionMapper`s anymore, which makes your app smaller, and less error-prone.
+> HTTP status codes (...) cannot always convey enough information about errors to be helpful. While humans using web browsers can often understand an HTML response content, non-human consumers of HTTP APIs have difficulty doing so.
+
+`quarkus-http-problem` helps address these concerns by providing:
+- **consistency** - it standardizes REST API error responses and ensures a consistent format, regardless of the JSON provider (Jackson vs JSON-B) or execution model (classic blocking vs reactive).   
+- **predictability** - whether an exception is expected (thrown intentionally) or unexpected, your API consumers get a similar and repeatable error format.  
+- **safety** - it helps prevent leaking implementation details such as stack traces, DTO names, and resource class names.
+- **time savings** - in most cases, you no longer need to implement your own JAX-RS `ExceptionMapper`s, which keeps your app smaller and less error-prone.
 
 See [Built-in Exception Mappers Wiki](https://github.com/quarkiverse/quarkus-http-problem/wiki#built-in-exception-mappers) for more details.
-
-From [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (abstract):
-
-> This document defines a "problem detail" to carry machine-readable details of errors in HTTP response content to avoid the need to define new error response formats for HTTP APIs.
-
-The introduction adds that HTTP status codes cannot always convey enough information about errors to be helpful, and that non-human consumers of HTTP APIs have difficulty interpreting HTML responses—hence a common JSON (and optional XML) format for problem details. See [Appendix D of RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457#appendix-D) for a list of changes from [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807).
 
 ## Getting started
 
@@ -109,7 +107,7 @@ More on throwing problems: [zalando/problem usage](https://github.com/zalando/pr
 
 ### `quarkus-http-problem`
 
-Published as `[io.quarkiverse.httpproblem:quarkus-http-problem](https://central.sonatype.com/artifact/io.quarkiverse.httpproblem/quarkus-http-problem)`. This line targets **Quarkus 3.32+**; add the dependency and version from **Getting started**. 
+Published as [io.quarkiverse.httpproblem:quarkus-http-problem](https://central.sonatype.com/artifact/io.quarkiverse.httpproblem/quarkus-http-problem). This line targets **Quarkus 3.32+**; add the dependency and version from **Getting started**. 
 
 If you run an **older Quarkus**, stay on `**quarkus-resteasy-problem`** until you upgrade (table in the subsection below), or bump Quarkus first and then switch here.
 


### PR DESCRIPTION
Reframe the README around RFC 9457 (RFC 7807 only as superseded reference), split “Getting started” from expanded versioning and legacy-coordinate tables, switch badge rows to plain links, require an explicit Maven version with a BOM note, and tidy examples and wording across the doc.

Ref: #480 