### PR TITLE
Fix for: NullPointerException on unauthenticated request when non-standard status code is used #601

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtils.java
@@ -24,10 +24,16 @@ final class HttpUnauthorizedUtils {
                                 .build();
                     }
 
-                    Response.Status status = Response.Status.fromStatusCode(challenge.status);
                     HttpProblem.Builder builder = HttpProblem.builder()
-                            .withStatus(status)
-                            .withTitle(status.getReasonPhrase());
+                            .withStatus(challenge.status);
+
+                    Response.Status status = Response.Status.fromStatusCode(challenge.status);
+                    if (status != null) {
+                        builder = builder.withTitle(status.getReasonPhrase());
+                    } else {
+                        builder = builder.withTitle("HTTP Status " + challenge.status);
+                    }
+
                     if (challenge.getHeaders() != null) {
                         for (CharSequence headerName : challenge.getHeaders().keySet()) {
                             builder = builder.withHeader(headerName.toString(), challenge.getHeaders().get(headerName));

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
@@ -31,7 +31,8 @@ class HttpUnauthorizedUtilsTest {
 
     @Test
     void shouldBuildUnauthorizedProblemWhenAuthenticatorReturns401Challenge() {
-        RoutingContext routingContext = routingContextReturningChallenge(401);
+        ChallengeData challenge = new ChallengeData(401, "WWW-Authenticate", "Bearer realm=\"example\"");
+        RoutingContext routingContext = routingContextReturningChallenge(challenge);
 
         HttpProblem problem = HttpUnauthorizedUtils.toProblem(routingContext, new RuntimeException("ignored"))
                 .await().atMost(Duration.ofSeconds(5));
@@ -39,6 +40,8 @@ class HttpUnauthorizedUtilsTest {
         assertThat(problem.getStatusCode()).isEqualTo(401);
         assertThat(problem.getTitle()).isEqualTo("Unauthorized");
         assertThat(problem.getDetail()).isNull();
+        assertThat(problem.getHeaders())
+                .containsEntry("WWW-Authenticate", "Bearer realm=\"example\"");
     }
 
     @Test
@@ -54,11 +57,15 @@ class HttpUnauthorizedUtilsTest {
     }
 
     private static RoutingContext routingContextReturningChallenge(int challengeStatusCode) {
+        return routingContextReturningChallenge(new ChallengeData(challengeStatusCode));
+    }
+
+    private static RoutingContext routingContextReturningChallenge(ChallengeData challenge) {
         RoutingContext routingContext = mock(RoutingContext.class);
         HttpAuthenticator authenticator = mock(HttpAuthenticator.class);
         when(routingContext.get(HttpAuthenticator.class.getName())).thenReturn(authenticator);
         when(authenticator.getChallenge(any(RoutingContext.class)))
-                .thenReturn(Uni.createFrom().item(new ChallengeData(challengeStatusCode)));
+                .thenReturn(Uni.createFrom().item(challenge));
         return routingContext;
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.httpproblem.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+class HttpUnauthorizedUtilsTest {
+
+    @Test
+    void shouldBuildUnauthorizedProblemWithoutRoutingContext() {
+        Exception exception = new IllegalArgumentException("Invalid credentials");
+
+        HttpProblem problem = HttpUnauthorizedUtils.toProblem(null, exception)
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(problem.getStatusCode()).isEqualTo(401);
+        assertThat(problem.getTitle()).isEqualTo("Unauthorized");
+        assertThat(problem.getDetail()).isEqualTo("Invalid credentials");
+    }
+
+    @Test
+    void shouldBuildUnauthorizedProblemWhenAuthenticatorReturns401Challenge() {
+        RoutingContext routingContext = routingContextReturningChallenge(401);
+
+        HttpProblem problem = HttpUnauthorizedUtils.toProblem(routingContext, new RuntimeException("ignored"))
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(problem.getStatusCode()).isEqualTo(401);
+        assertThat(problem.getTitle()).isEqualTo("Unauthorized");
+        assertThat(problem.getDetail()).isNull();
+    }
+
+    @Test
+    void shouldBuildProblemWhenAuthenticatorReturnsNonStandard499ChallengeStatus() {
+        RoutingContext routingContext = routingContextReturningChallenge(499);
+
+        HttpProblem problem = HttpUnauthorizedUtils.toProblem(routingContext, new RuntimeException("ignored"))
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(problem.getStatusCode()).isEqualTo(499);
+        assertThat(problem.getTitle()).isEqualTo("HTTP Status 499");
+        assertThat(problem.getDetail()).isNull();
+    }
+
+    private static RoutingContext routingContextReturningChallenge(int challengeStatusCode) {
+        RoutingContext routingContext = mock(RoutingContext.class);
+        HttpAuthenticator authenticator = mock(HttpAuthenticator.class);
+        when(routingContext.get(HttpAuthenticator.class.getName())).thenReturn(authenticator);
+        when(authenticator.getChallenge(any(RoutingContext.class)))
+                .thenReturn(Uni.createFrom().item(new ChallengeData(challengeStatusCode)));
+        return routingContext;
+    }
+}


### PR DESCRIPTION
Fixes #601 