### PR TITLE
Add per-mapper post-processor registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,33 @@ class CustomPostProcessor implements ProblemPostProcessor {
 }
 ```
 
+Custom post-processors registered as CDI beans are applied globally. If a particular mapper needs its own post-processing
+pipeline, pass a custom `PostProcessorsRegistry` to `ExceptionMapperBase`:
+
+```java
+class CustomExceptionMapper extends ExceptionMapperBase<CustomException> {
+
+    private static final PostProcessorsRegistry POST_PROCESSORS = new PostProcessorsRegistry(
+            () -> ExceptionMapperBase.postProcessorsRegistry.stream()
+                    .filter(processor -> !(processor instanceof ProblemLogger)));
+
+    CustomExceptionMapper() {
+        super(POST_PROCESSORS);
+    }
+
+    @Override
+    protected HttpProblem toProblem(CustomException exception) {
+        return HttpProblem.valueOf(Response.Status.BAD_REQUEST);
+    }
+}
+```
+
+`new PostProcessorsRegistry()` creates an empty custom registry. `new PostProcessorsRegistry(parentRegistry)` creates a
+custom registry that live-inherits from the parent registry and can register mapper-specific post-processors. The supplier
+constructor and `stream()` method can be used for more advanced live views, for example to filter globally registered
+post-processors. Custom-created registries do not include extension defaults unless they inherit them from another registry
+or register them explicitly.
+
 ## Troubles?
 
 If you have questions, concerns, bug reports, etc, please file an issue in this repository's Issue Tracker. You may also want to have a look at [troubleshooting FAQ](./TROUBLESHOOTING.md).

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
@@ -1,12 +1,19 @@
 package io.quarkiverse.httpproblem;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
+import org.slf4j.LoggerFactory;
+
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemPostProcessor;
 
 /**
  * Base class for all ExceptionMappers in this extension, takes care of mapping Exceptions to Problems, triggering
@@ -14,7 +21,22 @@ import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
  */
 public abstract class ExceptionMapperBase<E extends Throwable> implements ExceptionMapper<E> {
 
-    public static final PostProcessorsRegistry postProcessorsRegistry = new PostProcessorsRegistry();
+    private static final List<ProblemPostProcessor> DEFAULT_POST_PROCESSORS = List.of(
+            new ProblemLogger(LoggerFactory.getLogger("http-problem")),
+            new ProblemDefaultsProvider());
+
+    public static final PostProcessorsRegistry postProcessorsRegistry = new PostProcessorsRegistry(
+            DEFAULT_POST_PROCESSORS::stream);
+
+    private final PostProcessorsRegistry postProcessors;
+
+    protected ExceptionMapperBase() {
+        this(postProcessorsRegistry);
+    }
+
+    protected ExceptionMapperBase(PostProcessorsRegistry postProcessors) {
+        this.postProcessors = postProcessors;
+    }
 
     @Context
     UriInfo uriInfo;
@@ -23,7 +45,7 @@ public abstract class ExceptionMapperBase<E extends Throwable> implements Except
     public final Response toResponse(E exception) {
         HttpProblem problem = toProblem(exception);
         ProblemContext context = ProblemContext.of(exception, uriInfo);
-        HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);
+        HttpProblem finalProblem = postProcessors.applyPostProcessing(problem, context);
         return finalProblem.toResponse();
     }
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/MdcPropertiesInjector.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/MdcPropertiesInjector.java
@@ -11,7 +11,7 @@ import io.quarkiverse.httpproblem.HttpProblem;
  * Injects existing MDC properties listed in the configuration into final response. Missing MDC values and properties already
  * defined in Problem instance are skipped.
  */
-final class MdcPropertiesInjector implements ProblemPostProcessor {
+public final class MdcPropertiesInjector implements ProblemPostProcessor {
 
     private final Set<String> properties;
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
@@ -2,8 +2,8 @@ package io.quarkiverse.httpproblem.postprocessing;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.slf4j.LoggerFactory;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 
@@ -12,20 +12,27 @@ import io.quarkiverse.httpproblem.HttpProblem;
  */
 public final class PostProcessorsRegistry {
 
+    private final Supplier<Stream<ProblemPostProcessor>> inheritedProcessors;
     private final List<ProblemPostProcessor> processors = new CopyOnWriteArrayList<>();
 
     public PostProcessorsRegistry() {
-        reset();
+        this(Stream::empty);
+    }
+
+    public PostProcessorsRegistry(PostProcessorsRegistry parent) {
+        this(parent::stream);
+    }
+
+    public PostProcessorsRegistry(Supplier<Stream<ProblemPostProcessor>> inheritedProcessors) {
+        this.inheritedProcessors = inheritedProcessors;
     }
 
     /**
-     * Removes all registered post-processors and registers default ones. Used mainly for Quarkus dev mode (live-reload) tests
-     * where there's a need to reset registered processors because of config change.
+     * Removes all registered local post-processors. Used mainly for Quarkus dev mode (live-reload) tests where there's a
+     * need to reset registered processors because of config change.
      */
     public synchronized void reset() {
         processors.clear();
-        register(new ProblemLogger(LoggerFactory.getLogger("http-problem")));
-        register(new ProblemDefaultsProvider());
     }
 
     public synchronized void register(ProblemPostProcessor processor) {
@@ -42,10 +49,15 @@ public final class PostProcessorsRegistry {
      */
     public HttpProblem applyPostProcessing(HttpProblem problem, ProblemContext context) {
         HttpProblem finalProblem = problem;
+        Iterable<ProblemPostProcessor> processors = stream()::iterator;
         for (ProblemPostProcessor processor : processors) {
             finalProblem = processor.apply(finalProblem, context);
         }
         return finalProblem;
+    }
+
+    public Stream<ProblemPostProcessor> stream() {
+        return Stream.concat(inheritedProcessors.get(), processors.stream());
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProvider.java
@@ -7,7 +7,7 @@ import io.quarkiverse.httpproblem.InstanceUtils;
  * Replaces <code>null</code> value of <code>instance</code> with URI of currently served endpoint, i.e
  * <code>/products/123</code>
  */
-final class ProblemDefaultsProvider implements ProblemPostProcessor {
+public final class ProblemDefaultsProvider implements ProblemPostProcessor {
 
     @Override
     public int priority() {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -14,11 +14,11 @@ import io.quarkiverse.httpproblem.HttpProblem;
  * Logs problems with ERROR (for HTTP 5XX) or INFO (other exceptions) log level. In case of ERROR (HTTP 5XX) stack trace is
  * printed as well.
  */
-final class ProblemLogger implements ProblemPostProcessor {
+public final class ProblemLogger implements ProblemPostProcessor {
 
     private final Logger logger;
 
-    ProblemLogger(Logger logger) {
+    public ProblemLogger(Logger logger) {
         this.logger = logger;
     }
 

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ExceptionMapperBaseTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ExceptionMapperBaseTest.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.httpproblem;
+
+import static io.quarkiverse.httpproblem.HttpProblemMother.badRequestProblem;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemPostProcessor;
+
+class ExceptionMapperBaseTest {
+
+    @Test
+    void shouldUseDefaultPostProcessorsRegistryWhenCustomRegistryIsNotSupplied() {
+        TestMapper mapper = new TestMapper();
+        mapper.uriInfo = uriInfoWithPath("endpoint");
+
+        Response response = mapper.toResponse(new RuntimeException());
+
+        HttpProblem problem = (HttpProblem) response.getEntity();
+        assertThat(problem.getInstance()).hasToString("endpoint");
+    }
+
+    @Test
+    void shouldUseCustomPostProcessorsRegistry() {
+        PostProcessorsRegistry registry = new PostProcessorsRegistry();
+        registry.register(customPostProcessor());
+        TestMapper mapper = new TestMapper(registry);
+        mapper.uriInfo = uriInfoWithPath("endpoint");
+
+        Response response = mapper.toResponse(new RuntimeException());
+
+        HttpProblem problem = (HttpProblem) response.getEntity();
+        assertThat(problem.getParameters()).containsEntry("registry", "custom");
+        assertThat(problem.getInstance()).isNull();
+    }
+
+    private ProblemPostProcessor customPostProcessor() {
+        return (problem, context) -> HttpProblem.builder(problem)
+                .with("registry", "custom")
+                .build();
+    }
+
+    private UriInfo uriInfoWithPath(String path) {
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getPath()).thenReturn(path);
+        return uriInfo;
+    }
+
+    private static class TestMapper extends ExceptionMapperBase<RuntimeException> {
+
+        TestMapper() {
+        }
+
+        TestMapper(PostProcessorsRegistry registry) {
+            super(registry);
+        }
+
+        @Override
+        protected HttpProblem toProblem(RuntimeException exception) {
+            return badRequestProblem();
+        }
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
@@ -43,6 +43,51 @@ class PostProcessorsRegistryTest {
         assertThat(invocations).containsExactly(HIGHEST, MEDIUM, MEDIUM, MEDIUM);
     }
 
+    @Test
+    void shouldCreateEmptyRegistry() {
+        HttpProblem originalProblem = badRequestProblem();
+
+        HttpProblem finalProblem = new PostProcessorsRegistry()
+                .applyPostProcessing(originalProblem, simpleContext());
+
+        assertThat(finalProblem).isSameAs(originalProblem);
+    }
+
+    @Test
+    void shouldOnlyClearLocalProcessorsWhenResettingCustomRegistry() {
+        List<ProblemPostProcessor> inheritedProcessors = new ArrayList<>();
+        PostProcessorsRegistry customRegistry = new PostProcessorsRegistry(inheritedProcessors::stream);
+        inheritedProcessors.add(processorWithPriority(LOW));
+        customRegistry.register(processorWithPriority(MEDIUM));
+        customRegistry.reset();
+
+        customRegistry.applyPostProcessing(badRequestProblem(), simpleContext());
+
+        assertThat(invocations).containsExactly(LOW);
+    }
+
+    @Test
+    void shouldApplyLocalProcessorsAfterInheritedStream() {
+        PostProcessorsRegistry childRegistry = new PostProcessorsRegistry(registry);
+        registry.register(processorWithPriority(LOW));
+        childRegistry.register(processorWithPriority(HIGHEST));
+
+        childRegistry.applyPostProcessing(badRequestProblem(), simpleContext());
+
+        assertThat(invocations).containsExactly(LOW, HIGHEST);
+    }
+
+    @Test
+    void shouldUseSupplierStreamAtApplyTime() {
+        List<ProblemPostProcessor> inheritedProcessors = new ArrayList<>();
+        PostProcessorsRegistry registryWithLiveInheritedStream = new PostProcessorsRegistry(inheritedProcessors::stream);
+        inheritedProcessors.add(processorWithPriority(MEDIUM));
+
+        registryWithLiveInheritedStream.applyPostProcessing(badRequestProblem(), simpleContext());
+
+        assertThat(invocations).containsExactly(MEDIUM);
+    }
+
     ProblemPostProcessor processorWithPriority(int priority) {
         return new TestProcessor(priority);
     }


### PR DESCRIPTION
Adds per-mapper `PostProcessorsRegistry` customization by allowing `ExceptionMapperBase` subclasses to supply their own registry. Custom registries can be empty, inherit live from another registry, or use a supplier-backed stream for advanced filtering/composition, while extension defaults remain owned by the built-in global registry.

The idea was briefly explored in https://github.com/quarkiverse/quarkus-http-problem/issues/552#issuecomment-4450781434. This PR does not solve original issue.