### PR TITLE
Handle malformed and charset-qualified problem+json responses in ThrowingHttpProblemClientExceptionMapper

### DIFF
--- a/integration-test/rest-client/src/main/java/io/quarkiverse/httpproblem/client/DemoResource.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/httpproblem/client/DemoResource.java
@@ -44,4 +44,48 @@ public class DemoResource {
         selfClientWithMapper.doThrow();
     }
 
+    /**
+     * Returns a malformed application/problem+json body (not valid JSON).
+     **/
+    @GET
+    @Path("/throw-malformed")
+    @Produces("application/problem+json")
+    public Response throwMalformedProblem() {
+        return Response.status(409)
+                .type("application/problem+json")
+                .entity("this is not valid json {{{")
+                .build();
+    }
+
+    /**
+     * Returns application/problem+json with charset parameter appended.
+     */
+    @GET
+    @Path("/throw-with-charset")
+    @Produces("application/problem+json;charset=UTF-8")
+    public Response throwProblemWithCharset() {
+        throw HttpProblem.builder()
+                .withStatus(409)
+                .withTitle("Conflict from upstream service")
+                .withDetail("Nothing to add")
+                .build();
+    }
+
+    @Inject
+    @RestClient
+    SelfRestClientWithExceptionMapper selfClientWithMapperMalformed;
+
+    @GET
+    @Path("/throw-via-rest-client-with-mapper-malformed")
+    public void throwViaRestClientMalformed() {
+        selfClientWithMapperMalformed.doThrowMalformed();
+
+    }
+
+    @GET
+    @Path("/throw-via-rest-client-with-mapper-charset")
+    public void throwViaRestClientWithCharset() {
+        selfClientWithMapperMalformed.doThrowWithCharset();
+    }
+
 }

--- a/integration-test/rest-client/src/main/java/io/quarkiverse/httpproblem/client/SelfRestClient.java
+++ b/integration-test/rest-client/src/main/java/io/quarkiverse/httpproblem/client/SelfRestClient.java
@@ -2,6 +2,8 @@ package io.quarkiverse.httpproblem.client;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "self")
@@ -9,4 +11,16 @@ public interface SelfRestClient {
     @GET
     @Path("/throw")
     void doThrow();
+
+    @GET
+    @Path("/throw-malformed")
+    // The @Produces is only necessary for RESTEasy Classic. Quarkus REST is more permissive.
+    @Produces({MediaType.APPLICATION_JSON, "application/problem+json"})
+    void doThrowMalformed();
+
+    @GET
+    @Path("/throw-with-charset")
+    // The @Produces is only necessary for RESTEasy Classic. Quarkus REST is more permissive.
+    @Produces({MediaType.APPLICATION_JSON, "application/problem+json"})
+    void doThrowWithCharset();
 }

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientIT.java
@@ -43,4 +43,23 @@ class RestClientIT {
                 .body("instance", equalTo("/throw-via-rest-client-with-mapper"));
     }
 
+    @Test
+    void shouldNotCrashWhenUpstreamReturnsMalformedProblemBody() {
+        given()
+                .accept(ContentType.JSON)
+                .get("/throw-via-rest-client-with-mapper-malformed")
+                .then()
+                .statusCode(409); 
+    }
+
+    @Test
+    void shouldRethrowHttpProblemWhenContentTypeHasCharsetParameter() {    
+        given()
+                .accept(ContentType.JSON)
+                .get("/throw-via-rest-client-with-mapper-charset")
+                .then()
+                .statusCode(409)
+                .body("title", equalTo("Conflict from upstream service"));
+    }
+
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
@@ -1,8 +1,10 @@
 package io.quarkiverse.httpproblem.client;
 
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 
@@ -13,18 +15,37 @@ import io.quarkiverse.httpproblem.HttpProblem;
  */
 public class ThrowingHttpProblemClientExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
 
+    private static final Logger log = Logger.getLogger(ThrowingHttpProblemClientExceptionMapper.class);
+
     @Override
     public RuntimeException toThrowable(Response response) {
-        if (!HttpProblem.MEDIA_TYPE.isCompatible(response.getMediaType())) { // TODO add tests here where UTF+8 is appended to respons
+        if (!isProblemMediaType(response.getMediaType())) {
             return null; // Let others handle non-problem formats
         }
 
-        HttpProblem returnedProblem = response.readEntity(HttpProblem.class);
+        try {
+            HttpProblem returnedProblem = response.readEntity(HttpProblem.class);
+            // instance must be nullified, otherwise it will be propagated as-is
+            return HttpProblem.builder(returnedProblem)
+                    .withInstance(null)
+                    .build();
+        } catch (Exception e) {
+            log.debug("Failed to deserialize application/problem+json response body", e);
+            return null; // Let others handle unreadable responses
+        }
+    }
 
-        // instance must be nullified, otherwise it will be propagated as-is
-        return HttpProblem.builder(returnedProblem)
-                .withInstance(null)
-                .build();
+    /**
+     * Checks type and subtype only, ignoring parameters such as {@code charset=UTF-8}.
+     * {@link MediaType#isCompatible(MediaType)} also checks parameters, which causes it to reject
+     * {@code application/problem+json; charset=UTF-8} even though it is the same media type.
+     */
+    private static boolean isProblemMediaType(MediaType mediaType) {
+        if (mediaType == null) {
+            return false;
+        }
+        return HttpProblem.MEDIA_TYPE.getType().equalsIgnoreCase(mediaType.getType())
+                && HttpProblem.MEDIA_TYPE.getSubtype().equalsIgnoreCase(mediaType.getSubtype());
     }
 
 }


### PR DESCRIPTION
Don't expect everyone to return proper JSON.

This PR fixes 2 things:

- The initial code was using MediaType.isCompatible, which is too strict 
- When reading and deserializing the JSON payload, it did not handle failures
