### PR TITLE
Fix ProblemLogger early-exit guard suppressing 4xx logging

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -24,10 +24,6 @@ final class ProblemLogger implements ProblemPostProcessor {
 
     @Override
     public HttpProblem apply(HttpProblem problem, ProblemContext context) {
-        if (!logger.isErrorEnabled()) {
-            return problem;
-        }
-
         if (problem.getStatusCode() >= 500) {
             if (logger.isErrorEnabled()) {
                 logger.error(serialize(problem), context.cause);

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
@@ -3,7 +3,10 @@ package io.quarkiverse.httpproblem.postprocessing;
 import static io.quarkiverse.httpproblem.postprocessing.ProblemContextMother.simpleContext;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +69,52 @@ class ProblemLoggerTest {
         processor.apply(problem, ProblemContextMother.withCause(cause));
 
         verify(logger).error("status=500, title=\"my fault\"", cause);
+    }
+
+    @Test
+    void shouldLog4xxAtInfoWhenErrorIsDisabled() {
+        when(logger.isErrorEnabled()).thenReturn(false);
+        when(logger.isInfoEnabled()).thenReturn(true);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("your fault")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"your fault\"");
+    }
+
+    @Test
+    void shouldNotLog4xxWhenInfoIsDisabled() {
+        when(logger.isErrorEnabled()).thenReturn(true);
+        when(logger.isInfoEnabled()).thenReturn(false);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("your fault")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger, never()).info(anyString());
+    }
+
+    @Test
+    void shouldNotLog5xxWhenErrorIsDisabled() {
+        when(logger.isErrorEnabled()).thenReturn(false);
+        when(logger.isInfoEnabled()).thenReturn(true);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("my fault")
+                .withStatus(INTERNAL_SERVER_ERROR)
+                .build();
+        RuntimeException cause = new RuntimeException("hey");
+
+        processor.apply(problem, ProblemContextMother.withCause(cause));
+
+        verify(logger, never()).error(anyString(), any(Throwable.class));
     }
 
 }


### PR DESCRIPTION
ProblemLogger.apply() had a top-level if (!logger.isErrorEnabled()) return problem guard that prevented the method from ever reaching the INFO-level 4xx logging branch. This meant configuring the logger to WARN or higher, which silently suppressed all 4xx logging, even though 4xx problems log at INFO and should be controlled independently.

I removed the early exit so each branch checks its own log level independently. I added tests covering WARN, INFO, and ERROR log-level configurations.