### PR TITLE
Fix duplicate RestEasyClassicJsonbExceptionMapper registration

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -59,8 +59,6 @@ public class ProblemProcessor {
                         .thatHandles("jakarta.ws.rs.ForbiddenException"),
                 mapper(EXTENSION_MAIN_PACKAGE + "jaxrs.NotFoundExceptionMapper")
                         .thatHandles("jakarta.ws.rs.NotFoundException"),
-                mapper(EXTENSION_MAIN_PACKAGE + "jsonb.RestEasyClassicJsonbExceptionMapper")
-                        .thatHandles("jakarta.ws.rs.ProcessingException"),
 
                 mapper(EXTENSION_MAIN_PACKAGE + "security.UnauthorizedExceptionMapper")
                         .thatHandles("io.quarkus.security.UnauthorizedException").onlyIf(new RestEasyClassicDetector()),


### PR DESCRIPTION
RestEasyClassicJsonbExceptionMapper was registered twice in neededExceptionMappers(): once unconditionally and once gated by JsonBDetector. The unconditional entry meant the mapper was always included regardless of whether JSON-B was on the classpath. 