### PR TITLE
Fix instance field to produce RFC 7807/3986-compliant URI references

### DIFF
--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersIT.java
@@ -60,6 +60,6 @@ class GenericMappersIT {
         given()
                 .get("/non|existing path /with unwisecharacters")
                 .then()
-                .body("instance", equalTo("/non|existing path /with unwisecharacters"));
+                .body("instance", equalTo("/non%7Cexisting%20path%20/with%20unwisecharacters"));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
@@ -2,9 +2,6 @@ package io.quarkiverse.httpproblem;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 public final class InstanceUtils {
 
@@ -13,21 +10,14 @@ public final class InstanceUtils {
             return null;
         }
         try {
-            return new URI(encodeUnwiseCharacters(path));
+            return new URI(null, null, path, null);
         } catch (URISyntaxException e) {
             return null;
         }
     }
 
-    /**
-     * @see <a href="https://www.ietf.org/rfc/rfc2396.txt">About unwise characters in RFC-2396</a>
-     */
-    private static String encodeUnwiseCharacters(String path) {
-        return URLEncoder.encode(path, StandardCharsets.UTF_8);
-    }
-
     public static String instanceToPath(URI instance) {
-        return URLDecoder.decode(instance.toString(), StandardCharsets.UTF_8);
+        return instance.toASCIIString();
     }
 
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/InstanceUtilsTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/InstanceUtilsTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.httpproblem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+class InstanceUtilsTest {
+
+    @Test
+    void plainPathPreservesSlashes() {
+        URI uri = InstanceUtils.pathToInstance("/api/users/42");
+
+        assertThat(uri.toString()).isEqualTo("/api/users/42");
+        assertThat(uri.getPath()).isEqualTo("/api/users/42");
+    }
+
+    @Test
+    void spacesArePercentEncoded() {
+        URI uri = InstanceUtils.pathToInstance("/api/users/john doe");
+
+        assertThat(uri.toASCIIString()).isEqualTo("/api/users/john%20doe");
+        assertThat(uri.getPath()).isEqualTo("/api/users/john doe");
+    }
+
+    @Test
+    void unwiseCharactersAreEncoded() {
+        URI uri = InstanceUtils.pathToInstance("/path|with{unwise}chars");
+
+        assertThat(uri.toASCIIString()).doesNotContain("|").doesNotContain("{").doesNotContain("}");
+        assertThat(uri.getPath()).isEqualTo("/path|with{unwise}chars");
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        assertThat(InstanceUtils.pathToInstance(null)).isNull();
+    }
+
+    @Test
+    void roundTripPlainPath() {
+        String original = "/api/users/42";
+
+        String result = InstanceUtils.instanceToPath(InstanceUtils.pathToInstance(original));
+
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    void roundTripEncodesSpecialCharacters() {
+        URI uri = InstanceUtils.pathToInstance("/non|existing{path /with{unwise\\characters>#");
+
+        assertThat(InstanceUtils.instanceToPath(uri))
+                .isEqualTo("/non%7Cexisting%7Bpath%20/with%7Bunwise%5Ccharacters%3E%23");
+    }
+
+    @Test
+    void instanceToPathReturnsValidUriReference() {
+        URI uri = InstanceUtils.pathToInstance("/api/users/john doe");
+
+        assertThat(InstanceUtils.instanceToPath(uri)).isEqualTo("/api/users/john%20doe");
+    }
+
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JacksonProblemSerializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JacksonProblemSerializerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +17,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.HttpProblemMother;
+import io.quarkiverse.httpproblem.InstanceUtils;
 
 class JacksonProblemSerializerTest {
 
@@ -55,17 +55,17 @@ class JacksonProblemSerializerTest {
     }
 
     @Test
-    @DisplayName("Should decode uri for instance field")
-    void shouldDecodeUriForInstanceField() throws IOException {
+    @DisplayName("Should produce valid URI reference for instance field")
+    void shouldProduceValidUriReferenceForInstanceField() throws IOException {
         HttpProblem problem = HttpProblem.builder()
                 .withStatus(NOT_FOUND)
-                .withInstance(URI.create("%2Fnon%7Cexisting%7Bpath+%2Fwith%7Bunwise%5Ccharacters%3E%23"))
+                .withInstance(InstanceUtils.pathToInstance("/non|existing{path /with{unwise\\characters>#"))
                 .build();
 
         serializer.serialize(problem, jsonGenerator, null);
 
-        assertThat(serializedProblem()).contains("""
-                "instance":"/non|existing{path /with{unwise\\\\characters>#"}""");
+        assertThat(serializedProblem()).contains(
+                "\"instance\":\"/non%7Cexisting%7Bpath%20/with%7Bunwise%5Ccharacters%3E%23\"");
     }
 
     private String serializedProblem() throws IOException {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbProblemSerializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbProblemSerializerTest.java
@@ -4,7 +4,6 @@ import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.json.Json;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.HttpProblemMother;
+import io.quarkiverse.httpproblem.InstanceUtils;
 
 class JsonbProblemSerializerTest {
 
@@ -52,17 +52,17 @@ class JsonbProblemSerializerTest {
     }
 
     @Test
-    @DisplayName("Should decode uri for instance field")
-    void shouldDecodeUriForInstanceField() {
+    @DisplayName("Should produce valid URI reference for instance field")
+    void shouldProduceValidUriReferenceForInstanceField() {
         HttpProblem problem = HttpProblem.builder()
                 .withStatus(NOT_FOUND)
-                .withInstance(URI.create("%2Fnon%7Cexisting%7Bpath+%2Fwith%7Bunwise%5Ccharacters%3E%23"))
+                .withInstance(InstanceUtils.pathToInstance("/non|existing{path /with{unwise\\characters>#"))
                 .build();
 
         serializer.serialize(problem, jsonGenerator, null);
 
-        assertThat(serializedProblem()).contains("""
-                "instance":"/non|existing{path /with{unwise\\\\characters>#"}""");
+        assertThat(serializedProblem()).contains(
+                "\"instance\":\"/non%7Cexisting%7Bpath%20/with%7Bunwise%5Ccharacters%3E%23\"");
     }
 
     private String serializedProblem() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProviderTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProviderTest.java
@@ -43,7 +43,7 @@ class ProblemDefaultsProviderTest {
                 ProblemContext.of(new RuntimeException(), "/non|existing{path /with{unwise\\characters>#"));
 
         assertThat(problemWithUnwiseCharactersInPath.getInstance())
-                .hasPath("/non|existing{path+/with{unwise\\characters>#");
+                .hasPath("/non|existing{path /with{unwise\\characters>#");
     }
 
 }


### PR DESCRIPTION
`pathToInstance()` used `URLEncoder.encode()` which encoded the entire path, including `/` separators, producing values like `%2Fapi%2Fusers%2F42`:

- Replaced with `new URI(null, null, path, null)` which encodes only characters invalid in a URI path component (spaces, `|`, `{`, etc.) while preserving `/` as path separator,
- `instanceToPath()` now returns `toASCIIString()` so the serialized `instance` field is a valid [URI reference](https://datatracker.ietf.org/doc/html/rfc7807#section-3.1) per RFC 7807 / RFC 3986
