### PR TITLE
Replace static mutable state with CDI injection

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.httpproblem.deployment;
 
 import static io.quarkiverse.httpproblem.deployment.ExceptionMapperDefinition.mapper;
-import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.Arrays;
@@ -10,15 +9,22 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Priorities;
 
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkiverse.httpproblem.postprocessing.ProblemPostProcessor;
 import io.quarkiverse.httpproblem.postprocessing.ProblemRecorder;
+import io.quarkiverse.httpproblem.validation.ConstraintViolationConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -26,13 +32,13 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.jsonb.spi.JsonbDeserializerBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 
 public class ProblemProcessor {
@@ -138,33 +144,41 @@ public class ProblemProcessor {
     }
 
     @BuildStep(onlyIf = RestEasyClassicDetector.class)
-    void registerMappersForClassic(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, ProblemBuildConfig config) {
-        neededExceptionMappers(config).forEach(mapper -> providers.produce(
-                new ResteasyJaxrsProviderBuildItem(mapper.mapperClassName)));
+    void registerMappersForClassic(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, ProblemBuildConfig config,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        neededExceptionMappers(config).forEach(mapper -> {
+            providers.produce(new ResteasyJaxrsProviderBuildItem(mapper.mapperClassName));
+            additionalBeans.produce(new AdditionalBeanBuildItem(mapper.mapperClassName));
+        });
+
     }
 
     @BuildStep(onlyIf = RestEasyReactiveDetector.class)
-    void registerMappersForReactive(BuildProducer<ExceptionMapperBuildItem> providers, ProblemBuildConfig config) {
-        neededExceptionMappers(config).forEach(mapper -> providers.produce(
-                new ExceptionMapperBuildItem(mapper.mapperClassName,
-                        mapper.exceptionClassName, Priorities.AUTHENTICATION - 1, true)));
+    void registerMappersForReactive(BuildProducer<ExceptionMapperBuildItem> providers, ProblemBuildConfig config,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        neededExceptionMappers(config).forEach(mapper -> {
+            providers.produce(
+                    new ExceptionMapperBuildItem(mapper.mapperClassName,
+                            mapper.exceptionClassName, Priorities.AUTHENTICATION - 1, true));
+            additionalBeans.produce(new AdditionalBeanBuildItem(mapper.mapperClassName));
+        });
     }
 
-    // Unauthorized/AuthenticationFailed handling in Quarkus REST is reactive: it needs Vert.x RoutingContext and
-    // asynchronous challenge/response resolution (Uni<Response>). These classes therefore use
-    // @ServerExceptionMapper methods (not JAX-RS ExceptionMapper<T> providers) and must be registered as custom mappers.
     @BuildStep(onlyIf = RestEasyReactiveDetector.class)
     void registerCustomExceptionMappers(BuildProducer<CustomExceptionMapperBuildItem> customExceptionMapper,
-            ProblemBuildConfig config) {
+            ProblemBuildConfig config, BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        String unauthorized = EXTENSION_MAIN_PACKAGE + "security.UnauthorizedExceptionReactiveMapper";
+        String authentication = EXTENSION_MAIN_PACKAGE + "security.AuthenticationFailedExceptionReactiveMapper";
+
         Map<String, ProblemBuildConfig.MapperConfig> mapperConfig = config.mapper();
-        if (isMapperEnabled("io.quarkus.security.UnauthorizedException", mapperConfig)) {
-            customExceptionMapper.produce(
-                    new CustomExceptionMapperBuildItem(
-                            EXTENSION_MAIN_PACKAGE + "security.UnauthorizedExceptionReactiveMapper"));
+        if (isMapperEnabled(unauthorized, mapperConfig)) {
+            customExceptionMapper.produce(new CustomExceptionMapperBuildItem(unauthorized));
+            additionalBeans.produce(new AdditionalBeanBuildItem(unauthorized));
         }
-        if (isMapperEnabled("io.quarkus.security.AuthenticationFailedException", mapperConfig)) {
-            customExceptionMapper.produce(new CustomExceptionMapperBuildItem(
-                    EXTENSION_MAIN_PACKAGE + "security.AuthenticationFailedExceptionReactiveMapper"));
+
+        if (isMapperEnabled(authentication, mapperConfig)) {
+            customExceptionMapper.produce(new CustomExceptionMapperBuildItem(authentication));
+            additionalBeans.produce(new AdditionalBeanBuildItem(authentication));
         }
     }
 
@@ -208,33 +222,39 @@ public class ProblemProcessor {
                 .build();
     }
 
+    @BuildStep
+    void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(PostProcessorsRegistry.class));
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemLogger.class));
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemDefaultsProvider.class));
+    }
+
     @Record(STATIC_INIT)
     @BuildStep
-    void resetRecorder(ProblemRecorder recorder, LiveReloadBuildItem liveReload) {
-        if (liveReload.isLiveReload()) {
-            recorder.reset();
+    SyntheticBeanBuildItem setupMdc(ProblemRecorder recorder, ProblemBuildConfig config) {
+        if (config.includeMdcProperties().isEmpty()) {
+            return null;
         }
+        RuntimeValue<MdcPropertiesInjector> runtimeValue = recorder.createMdcInjector(config.includeMdcProperties());
+        return SyntheticBeanBuildItem.configure(MdcPropertiesInjector.class)
+                .scope(Singleton.class)
+                .addType(ProblemPostProcessor.class)
+                .runtimeValue(runtimeValue)
+                .unremovable()
+                .done();
     }
 
-    @Record(RUNTIME_INIT)
+    @Record(STATIC_INIT)
     @BuildStep
-    void setupMdc(ProblemRecorder recorder, ProblemBuildConfig config) {
-        recorder.configureMdc(config.includeMdcProperties());
-    }
-
-    @Record(RUNTIME_INIT)
-    @BuildStep
-    void registerCustomPostProcessors(ProblemRecorder recorder) {
-        recorder.registerCustomPostProcessors();
-    }
-
-    @Record(RUNTIME_INIT)
-    @BuildStep
-    void configureConstraintViolationMapper(ProblemRecorder recorder, ProblemBuildConfig config) {
-        if (config.constraintViolation() != null) {
-            recorder.configureConstraintViolationMapper(config.constraintViolation().status(),
-                    config.constraintViolation().title());
-        }
+    SyntheticBeanBuildItem configureConstraintViolation(ProblemRecorder recorder, ProblemBuildConfig config) {
+        int status = config.constraintViolation() != null ? config.constraintViolation().status() : 400;
+        String title = config.constraintViolation() != null ? config.constraintViolation().title() : "Bad Request";
+        RuntimeValue<ConstraintViolationConfig> runtimeValue = recorder.createConstraintViolationConfig(status, title);
+        return SyntheticBeanBuildItem.configure(ConstraintViolationConfig.class)
+                .scope(Singleton.class)
+                .runtimeValue(runtimeValue)
+                .unremovable()
+                .done();
     }
 
     @BuildStep

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/DefaultExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/DefaultExceptionMapper.java
@@ -3,10 +3,13 @@ package io.quarkiverse.httpproblem;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Default exception mapper processing all exceptions not matching any more specific mapper.
@@ -15,6 +18,14 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 @APIResponse(responseCode = "500", description = "Internal Server Error: the server encountered an unexpected condition that prevented it from fulfilling the request")
 public final class DefaultExceptionMapper extends ExceptionMapperBase<Exception>
         implements ExceptionMapper<Exception> {
+
+    public DefaultExceptionMapper() {
+    }
+
+    @Inject
+    public DefaultExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(Exception exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.httpproblem;
 
+import java.util.Objects;
+
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
@@ -8,19 +10,24 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
 
-/**
- * Base class for all ExceptionMappers in this extension, takes care of mapping Exceptions to Problems, triggering
- * post-processing stage, and creating final JaxRS Response.
- */
 public abstract class ExceptionMapperBase<E extends Throwable> implements ExceptionMapper<E> {
 
-    public static final PostProcessorsRegistry postProcessorsRegistry = new PostProcessorsRegistry();
+    private PostProcessorsRegistry postProcessorsRegistry;
 
     @Context
     UriInfo uriInfo;
 
+    protected ExceptionMapperBase() {
+    }
+
+    protected ExceptionMapperBase(PostProcessorsRegistry postProcessorsRegistry) {
+        this.postProcessorsRegistry = postProcessorsRegistry;
+    }
+
     @Override
     public final Response toResponse(E exception) {
+        Objects.requireNonNull(postProcessorsRegistry,
+                "PostProcessorsRegistry not injected — mapper must be instantiated via CDI");
         HttpProblem problem = toProblem(exception);
         ProblemContext context = ProblemContext.of(exception, uriInfo);
         HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblemMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblemMapper.java
@@ -1,10 +1,21 @@
 package io.quarkiverse.httpproblem;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
+
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 public final class HttpProblemMapper extends ExceptionMapperBase<HttpProblem> {
+
+    public HttpProblemMapper() {
+    }
+
+    @Inject
+    public HttpProblemMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(HttpProblem exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/ZalandoProblemMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/ZalandoProblemMapper.java
@@ -3,16 +3,27 @@ package io.quarkiverse.httpproblem;
 import java.util.Optional;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
 import org.zalando.problem.ThrowableProblem;
+
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Mapper for ThrowableProblem exception from Zalando Problem library.
  */
 @Priority(Priorities.USER)
 public final class ZalandoProblemMapper extends ExceptionMapperBase<ThrowableProblem> {
+
+    public ZalandoProblemMapper() {
+    }
+
+    @Inject
+    public ZalandoProblemMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(ThrowableProblem exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
@@ -12,12 +13,21 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Mapper for Jackson InvalidFormatException, which is more specialised version of JsonProcessingException
  */
 @Priority(Priorities.USER)
 public final class InvalidFormatExceptionMapper extends ExceptionMapperBase<InvalidFormatException> {
+
+    public InvalidFormatExceptionMapper() {
+    }
+
+    @Inject
+    public InvalidFormatExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(InvalidFormatException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
@@ -3,18 +3,28 @@ package io.quarkiverse.httpproblem.jackson;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Mapper for Jackson payload processing exceptions.
  */
 @Priority(Priorities.USER)
 public final class JsonProcessingExceptionMapper extends ExceptionMapperBase<JsonProcessingException> {
+
+    public JsonProcessingExceptionMapper() {
+    }
+
+    @Inject
+    public JsonProcessingExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(JsonProcessingException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapper.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.httpproblem.jackson;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * UnrecognizedPropertyException is thrown by Jackson, when request payload json does not fit DTO object with @Valid annotation
@@ -15,6 +17,14 @@ import io.quarkiverse.httpproblem.HttpProblem;
  */
 @Priority(Priorities.USER - 1)
 public final class UnrecognizedPropertyExceptionMapper extends ExceptionMapperBase<UnrecognizedPropertyException> {
+
+    public UnrecognizedPropertyExceptionMapper() {
+    }
+
+    @Inject
+    public UnrecognizedPropertyExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(UnrecognizedPropertyException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/JaxRsForbiddenExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/JaxRsForbiddenExceptionMapper.java
@@ -3,6 +3,7 @@ package io.quarkiverse.httpproblem.jaxrs;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -11,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Mapper overriding default Quarkus exception mapper to make all error responses compliant with RFC7807.
@@ -19,6 +21,14 @@ import io.quarkiverse.httpproblem.HttpProblem;
 @APIResponse(responseCode = "403", description = "Forbidden: server understood the request but refused to process it")
 public final class JaxRsForbiddenExceptionMapper extends ExceptionMapperBase<ForbiddenException>
         implements ExceptionMapper<ForbiddenException> {
+
+    public JaxRsForbiddenExceptionMapper() {
+    }
+
+    @Inject
+    public JaxRsForbiddenExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(ForbiddenException e) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapper.java
@@ -3,6 +3,7 @@ package io.quarkiverse.httpproblem.jaxrs;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -11,11 +12,20 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 @APIResponse(responseCode = "404", description = "Not Found: server cannot find the requested resource")
 public final class NotFoundExceptionMapper extends ExceptionMapperBase<NotFoundException>
         implements ExceptionMapper<NotFoundException> {
+
+    public NotFoundExceptionMapper() {
+    }
+
+    @Inject
+    public NotFoundExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(NotFoundException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapper.java
@@ -3,18 +3,28 @@ package io.quarkiverse.httpproblem.jaxrs;
 import java.util.Optional;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Generic exception mapper for JaxRS WebApplicationExceptions - it passes status and message to application/problem response.
  */
 @Priority(Priorities.USER)
 public final class WebApplicationExceptionMapper extends ExceptionMapperBase<WebApplicationException> {
+
+    public WebApplicationExceptionMapper() {
+    }
+
+    @Inject
+    public WebApplicationExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(WebApplicationException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
@@ -3,14 +3,24 @@ package io.quarkiverse.httpproblem.jsonb;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.json.bind.JsonbException;
 import jakarta.ws.rs.Priorities;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 public final class JsonbExceptionMapper extends ExceptionMapperBase<JsonbException> {
+
+    public JsonbExceptionMapper() {
+    }
+
+    @Inject
+    public JsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(JsonbException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
@@ -4,14 +4,24 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ProcessingException;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 public final class RestEasyClassicJsonbExceptionMapper extends ExceptionMapperBase<ProcessingException> {
+
+    public RestEasyClassicJsonbExceptionMapper() {
+    }
+
+    @Inject
+    public RestEasyClassicJsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     /**
      * Unfortunately Quarkus+JsonB throws ProcessingException, not JsonbException in case of malformed payload body, so `cause`

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/MdcPropertiesInjector.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/MdcPropertiesInjector.java
@@ -11,7 +11,7 @@ import io.quarkiverse.httpproblem.HttpProblem;
  * Injects existing MDC properties listed in the configuration into final response. Missing MDC values and properties already
  * defined in Problem instance are skipped.
  */
-final class MdcPropertiesInjector implements ProblemPostProcessor {
+public class MdcPropertiesInjector implements ProblemPostProcessor {
 
     private final Set<String> properties;
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
@@ -1,45 +1,34 @@
 package io.quarkiverse.httpproblem.postprocessing;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.slf4j.LoggerFactory;
-
 import io.quarkiverse.httpproblem.HttpProblem;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import java.util.List;
 
 /**
- * Container for prioritised list of Problem post-processors. This class is thread-safe.
+ * Container for prioritised list of Problem post-processors.
+ * Collects all CDI beans implementing ProblemPostProcessor and sorts them by priority at startup.
  */
-public final class PostProcessorsRegistry {
+@ApplicationScoped
+public class PostProcessorsRegistry {
 
-    private final List<ProblemPostProcessor> processors = new CopyOnWriteArrayList<>();
+    private List<ProblemPostProcessor> processors;
 
-    public PostProcessorsRegistry() {
-        reset();
+    @Inject
+    PostProcessorsRegistry(Instance<ProblemPostProcessor> processorInstances) {
+        this.processors = processorInstances.stream()
+                .sorted(ProblemPostProcessor.DEFAULT_ORDERING)
+                .toList();
     }
 
-    /**
-     * Removes all registered post-processors and registers default ones. Used mainly for Quarkus dev mode (live-reload) tests
-     * where there's a need to reset registered processors because of config change.
-     */
-    public synchronized void reset() {
-        processors.clear();
-        register(new ProblemLogger(LoggerFactory.getLogger("http-problem")));
-        register(new ProblemDefaultsProvider());
+    public PostProcessorsRegistry(List<ProblemPostProcessor> processors) {
+        this.processors = processors.stream()
+                .sorted(ProblemPostProcessor.DEFAULT_ORDERING)
+                .toList();
     }
 
-    public synchronized void register(ProblemPostProcessor processor) {
-        processors.add(processor);
-        processors.sort(ProblemPostProcessor.DEFAULT_ORDERING);
-    }
-
-    /**
-     * Applies all registered post-processors on a given Problem, in prioritized order.
-     *
-     * @param problem Original Problem produced by Exception Mapper
-     * @param context Additional info on cause (original exception caught by ExceptionMapper) and HTTP request
-     * @return Enhanced version of original Problem
-     */
     public HttpProblem applyPostProcessing(HttpProblem problem, ProblemContext context) {
         HttpProblem finalProblem = problem;
         for (ProblemPostProcessor processor : processors) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemDefaultsProvider.java
@@ -1,13 +1,12 @@
 package io.quarkiverse.httpproblem.postprocessing;
 
+import jakarta.inject.Singleton;
+
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.InstanceUtils;
 
-/**
- * Replaces <code>null</code> value of <code>instance</code> with URI of currently served endpoint, i.e
- * <code>/products/123</code>
- */
-final class ProblemDefaultsProvider implements ProblemPostProcessor {
+@Singleton
+public class ProblemDefaultsProvider implements ProblemPostProcessor {
 
     @Override
     public int priority() {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -6,17 +6,21 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.inject.Singleton;
+
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 
-/**
- * Logs problems with ERROR (for HTTP 5XX) or INFO (other exceptions) log level. In case of ERROR (HTTP 5XX) stack trace is
- * printed as well.
- */
-final class ProblemLogger implements ProblemPostProcessor {
+@Singleton
+public class ProblemLogger implements ProblemPostProcessor {
 
     private final Logger logger;
+
+    public ProblemLogger() {
+        this(LoggerFactory.getLogger("http-problem"));
+    }
 
     ProblemLogger(Logger logger) {
         this.logger = logger;

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
@@ -2,34 +2,19 @@ package io.quarkiverse.httpproblem.postprocessing;
 
 import java.util.Set;
 
-import jakarta.enterprise.inject.spi.CDI;
-
-import io.quarkiverse.httpproblem.ExceptionMapperBase;
-import io.quarkiverse.httpproblem.validation.ConstraintViolationExceptionMapper;
+import io.quarkiverse.httpproblem.validation.ConstraintViolationConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
-/**
- * Quarkus Recorder that applies configuration in the runtime.
- */
 @Recorder
 public class ProblemRecorder {
 
-    public void reset() {
-        ExceptionMapperBase.postProcessorsRegistry.reset();
+    public RuntimeValue<MdcPropertiesInjector> createMdcInjector(Set<String> properties) {
+        return new RuntimeValue<>(new MdcPropertiesInjector(properties));
     }
 
-    public void configureMdc(Set<String> includeMdcProperties) {
-        if (!includeMdcProperties.isEmpty()) {
-            ExceptionMapperBase.postProcessorsRegistry.register(new MdcPropertiesInjector(includeMdcProperties));
-        }
+    public RuntimeValue<ConstraintViolationConfig> createConstraintViolationConfig(int status, String title) {
+        return new RuntimeValue<>(new ConstraintViolationConfig(status, title));
     }
 
-    public void registerCustomPostProcessors() {
-        CDI.current().select(ProblemPostProcessor.class)
-                .forEach(ExceptionMapperBase.postProcessorsRegistry::register);
-    }
-
-    public void configureConstraintViolationMapper(int status, String title) {
-        ConstraintViolationExceptionMapper.configure(status, title);
-    }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapper.java
@@ -3,10 +3,12 @@ package io.quarkiverse.httpproblem.security;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkus.security.AuthenticationCompletionException;
 
 /**
@@ -20,6 +22,14 @@ import io.quarkus.security.AuthenticationCompletionException;
  */
 @Priority(Priorities.USER - 1)
 public final class AuthenticationCompletionExceptionMapper extends ExceptionMapperBase<AuthenticationCompletionException> {
+
+    public AuthenticationCompletionExceptionMapper() {
+    }
+
+    @Inject
+    public AuthenticationCompletionExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(AuthenticationCompletionException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapper.java
@@ -1,33 +1,34 @@
 package io.quarkiverse.httpproblem.security;
 
 import jakarta.annotation.Priority;
-import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
-/**
- * Mapper overriding default Quarkus exception mapper to make all error responses compliant with RFC7807.
- */
 @Priority(Priorities.USER - 1)
 public final class AuthenticationFailedExceptionMapper extends ExceptionMapperBase<AuthenticationFailedException> {
 
-    @Override
-    protected HttpProblem toProblem(AuthenticationFailedException exception) {
-        return HttpUnauthorizedUtils.toProblem(currentVertxRequest().getCurrent(), exception)
-                .await().indefinitely();
+    CurrentVertxRequest currentVertxRequest;
+
+    public AuthenticationFailedExceptionMapper() {
     }
 
-    volatile CurrentVertxRequest currentVertxRequest;
+    @Inject
+    public AuthenticationFailedExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            CurrentVertxRequest currentVertxRequest) {
+        super(postProcessorsRegistry);
+        this.currentVertxRequest = currentVertxRequest;
+    }
 
-    private CurrentVertxRequest currentVertxRequest() {
-        if (currentVertxRequest == null) {
-            currentVertxRequest = CDI.current().select(CurrentVertxRequest.class).get();
-        }
-        return currentVertxRequest;
+    @Override
+    protected HttpProblem toProblem(AuthenticationFailedException exception) {
+        return HttpUnauthorizedUtils.toProblem(currentVertxRequest.getCurrent(), exception)
+                .await().indefinitely();
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionReactiveMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionReactiveMapper.java
@@ -1,28 +1,33 @@
 package io.quarkiverse.httpproblem.security;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
-import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
 import io.quarkus.security.AuthenticationFailedException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
-/**
- * Mapper overriding default Quarkus exception mapper to make all error responses compliant with RFC7807.
- */
 public final class AuthenticationFailedExceptionReactiveMapper {
+
+    private final PostProcessorsRegistry postProcessorsRegistry;
+
+    @Inject
+    public AuthenticationFailedExceptionReactiveMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        this.postProcessorsRegistry = postProcessorsRegistry;
+    }
 
     @ServerExceptionMapper(value = AuthenticationFailedException.class, priority = Priorities.USER - 1)
     public Uni<Response> handle(RoutingContext routingContext, AuthenticationFailedException exception) {
         return HttpUnauthorizedUtils.toProblem(routingContext, exception)
                 .map(problem -> {
                     ProblemContext context = ProblemContext.of(exception, routingContext.normalizedPath());
-                    HttpProblem finalProblem = ExceptionMapperBase.postProcessorsRegistry.applyPostProcessing(problem,
+                    HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem,
                             context);
                     return finalProblem.toResponse();
                 });

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapper.java
@@ -1,11 +1,13 @@
 package io.quarkiverse.httpproblem.security;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkus.security.AuthenticationRedirectException;
 
 /**
@@ -13,6 +15,14 @@ import io.quarkus.security.AuthenticationRedirectException;
  */
 @Priority(Priorities.USER - 1)
 public final class AuthenticationRedirectExceptionMapper extends ExceptionMapperBase<AuthenticationRedirectException> {
+
+    public AuthenticationRedirectExceptionMapper() {
+    }
+
+    @Inject
+    public AuthenticationRedirectExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(AuthenticationRedirectException exception) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapper.java
@@ -3,6 +3,7 @@ package io.quarkiverse.httpproblem.security;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
@@ -10,6 +11,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkus.security.ForbiddenException;
 
 /**
@@ -19,6 +21,14 @@ import io.quarkus.security.ForbiddenException;
 @APIResponse(responseCode = "403", description = "Forbidden: server understood the request but refused to process it")
 public final class ForbiddenExceptionMapper extends ExceptionMapperBase<ForbiddenException>
         implements ExceptionMapper<ForbiddenException> {
+
+    public ForbiddenExceptionMapper() {
+    }
+
+    @Inject
+    public ForbiddenExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(ForbiddenException e) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapper.java
@@ -1,7 +1,7 @@
 package io.quarkiverse.httpproblem.security;
 
 import jakarta.annotation.Priority;
-import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
@@ -9,30 +9,31 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
-/**
- * Mapper overriding default Quarkus exception mapper to make all error responses compliant with RFC7807.
- */
 @Priority(Priorities.USER)
 @APIResponse(responseCode = "401", description = "Unauthorized: request was not successful because it lacks valid authentication credentials for the requested resource")
 public final class UnauthorizedExceptionMapper extends ExceptionMapperBase<UnauthorizedException>
         implements ExceptionMapper<UnauthorizedException> {
 
-    @Override
-    protected HttpProblem toProblem(UnauthorizedException exception) {
-        return HttpUnauthorizedUtils.toProblem(currentVertxRequest().getCurrent(), exception)
-                .await().indefinitely();
+    CurrentVertxRequest currentVertxRequest;
+
+    public UnauthorizedExceptionMapper() {
     }
 
-    volatile CurrentVertxRequest currentVertxRequest;
+    @Inject
+    public UnauthorizedExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            CurrentVertxRequest currentVertxRequest) {
+        super(postProcessorsRegistry);
+        this.currentVertxRequest = currentVertxRequest;
+    }
 
-    private CurrentVertxRequest currentVertxRequest() {
-        if (currentVertxRequest == null) {
-            currentVertxRequest = CDI.current().select(CurrentVertxRequest.class).get();
-        }
-        return currentVertxRequest;
+    @Override
+    protected HttpProblem toProblem(UnauthorizedException exception) {
+        return HttpUnauthorizedUtils.toProblem(currentVertxRequest.getCurrent(), exception)
+                .await().indefinitely();
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionReactiveMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionReactiveMapper.java
@@ -1,22 +1,27 @@
 package io.quarkiverse.httpproblem.security;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
-import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
 import io.quarkus.security.UnauthorizedException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
-/**
- * Mapper overriding default Quarkus exception mapper to make all error responses compliant with RFC7807.
- */
 public final class UnauthorizedExceptionReactiveMapper {
+
+    private final PostProcessorsRegistry postProcessorsRegistry;
+
+    @Inject
+    public UnauthorizedExceptionReactiveMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        this.postProcessorsRegistry = postProcessorsRegistry;
+    }
 
     @ServerExceptionMapper(value = UnauthorizedException.class, priority = Priorities.USER - 1)
     @APIResponse(responseCode = "401", description = "Unauthorized: request was not successful because it lacks valid authentication credentials for the requested resource")
@@ -24,7 +29,7 @@ public final class UnauthorizedExceptionReactiveMapper {
         return HttpUnauthorizedUtils.toProblem(routingContext, exception)
                 .map(problem -> {
                     ProblemContext context = ProblemContext.of(exception, routingContext.normalizedPath());
-                    HttpProblem finalProblem = ExceptionMapperBase.postProcessorsRegistry.applyPostProcessing(problem,
+                    HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem,
                             context);
                     return finalProblem.toResponse();
                 });

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ConstraintViolationConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ConstraintViolationConfig.java
@@ -1,0 +1,4 @@
+package io.quarkiverse.httpproblem.validation;
+
+public record ConstraintViolationConfig(int status, String title) {
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapper.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
@@ -26,6 +27,7 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Exception Mapper for ConstraintViolationException from Bean Validation API. Hibernate Validator, among others throw
@@ -54,24 +56,24 @@ public final class ConstraintViolationExceptionMapper extends ExceptionMapperBas
             .flatMap(Optional::stream)
             .toList();
 
-    private record ConstraintViolationConfig(int status, String title) {
-        // Create a record to store immutable data.
+    private ConstraintViolationConfig constraintViolationConfig;
+
+    public ConstraintViolationExceptionMapper() {
     }
 
-    private static volatile ConstraintViolationConfig DEFAULT = new ConstraintViolationConfig(400, "Bad Request");
+    @Inject
+    public ConstraintViolationExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            ConstraintViolationConfig constraintViolationConfig) {
+        super(postProcessorsRegistry);
+        this.constraintViolationConfig = constraintViolationConfig;
+    }
 
     @Context
     ResourceInfo resourceInfo;
 
-    // Called from the recorder, only once.
-    public static void configure(int status, String title) {
-        DEFAULT = new ConstraintViolationConfig(status, title);
-    }
-
     @Override
     protected HttpValidationProblem toProblem(ConstraintViolationException exception) {
-        ConstraintViolationConfig config = DEFAULT; // single volatile read
-        return new HttpValidationProblem(config.status(), config.title(),
+        return new HttpValidationProblem(constraintViolationConfig.status(), constraintViolationConfig.title(),
                 toViolations(exception.getConstraintViolations()));
     }
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ValidationExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/validation/ValidationExceptionMapper.java
@@ -3,11 +3,13 @@ package io.quarkiverse.httpproblem.validation;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.Priorities;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
  * Exception Mapper for generic ValidationException from Bean Validation API.
@@ -16,6 +18,14 @@ import io.quarkiverse.httpproblem.HttpProblem;
  */
 @Priority(Priorities.USER)
 public final class ValidationExceptionMapper extends ExceptionMapperBase<ValidationException> {
+
+    public ValidationExceptionMapper() {
+    }
+
+    @Inject
+    public ValidationExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+        super(postProcessorsRegistry);
+    }
 
     @Override
     protected HttpProblem toProblem(ValidationException exception) {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemMapperTest.java
@@ -2,13 +2,21 @@ package io.quarkiverse.httpproblem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
 class HttpProblemMapperTest {
 
-    HttpProblemMapper mapper = new HttpProblemMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    HttpProblemMapper mapper = new HttpProblemMapper(registry);
 
     @Test
     void responseShouldIncludeHeaders() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ProblemMapperBenchmark.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ProblemMapperBenchmark.java
@@ -4,6 +4,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.core.Response;
@@ -28,9 +30,10 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import com.google.common.collect.Sets;
-
-import io.quarkiverse.httpproblem.postprocessing.ProblemRecorder;
+import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
 /**
  * JMH benchmark for selected exception Mapper with all post-processors enabled + junit runner test for convenience.
@@ -49,14 +52,17 @@ public class ProblemMapperBenchmark {
     @State(Scope.Thread)
     public static class BenchmarkState {
 
-        public final HttpProblemMapper mapper = new HttpProblemMapper();
+        public HttpProblemMapper mapper;
 
         public final HttpProblem problem = HttpProblemMother.complexProblem().build();
 
         @Setup(Level.Trial)
         public void initMapper() {
-            ProblemRecorder recorder = new ProblemRecorder();
-            recorder.configureMdc(Sets.newHashSet("uuid"));
+            PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
+                    new ProblemLogger(),
+                    new ProblemDefaultsProvider(),
+                    new MdcPropertiesInjector(Set.of("uuid"))));
+            mapper = new HttpProblemMapper(registry);
         }
     }
 

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
@@ -3,15 +3,23 @@ package io.quarkiverse.httpproblem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.zalando.problem.Status.BAD_REQUEST;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
 class ZalandoProblemMapperTest {
 
-    ZalandoProblemMapper mapper = new ZalandoProblemMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    ZalandoProblemMapper mapper = new ZalandoProblemMapper(registry);
 
     @Test
     void responseShouldUseProblemStatus() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
@@ -3,6 +3,8 @@ package io.quarkiverse.httpproblem.jackson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
@@ -12,10 +14,15 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
 class InvalidFormatExceptionMapperTest {
 
-    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp400WithFieldInfo() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.ws.rs.core.Response;
 
@@ -13,10 +14,15 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
 class UnrecognizedPropertyExceptionMapperTest {
 
-    UnrecognizedPropertyExceptionMapper mapper = new UnrecognizedPropertyExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    UnrecognizedPropertyExceptionMapper mapper = new UnrecognizedPropertyExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp400() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapperTest.java
@@ -2,14 +2,22 @@ package io.quarkiverse.httpproblem.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
 class NotFoundExceptionMapperTest {
 
-    NotFoundExceptionMapper mapper = new NotFoundExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    NotFoundExceptionMapper mapper = new NotFoundExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp404() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapperTest.java
@@ -6,6 +6,7 @@ import static jakarta.ws.rs.core.HttpHeaders.RETRY_AFTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.util.List;
 
 import jakarta.ws.rs.RedirectionException;
 import jakarta.ws.rs.WebApplicationException;
@@ -15,12 +16,17 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
 class WebApplicationExceptionMapperTest {
 
     static final MediaType MEDIA_TYPE_SHOULD_BE_IGNORED = MediaType.TEXT_PLAIN_TYPE;
 
-    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper(registry);
 
     @Test
     void shouldMapAllBasicFields() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
@@ -2,15 +2,23 @@ package io.quarkiverse.httpproblem.jsonb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.json.bind.JsonbException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
 class RestEasyClassicJsonbExceptionMapperTest {
 
-    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry);
 
     @Test
     void processingExceptionShouldProduceHttp500() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
@@ -17,14 +17,14 @@ class PostProcessorsRegistryTest {
     static final int MEDIUM = 10;
     static final int LOW = 9;
 
-    PostProcessorsRegistry registry = new PostProcessorsRegistry();
     List<Integer> invocations = new ArrayList<>();
 
     @Test
     void shouldIterateFromHighestToLowestPriority() {
-        registry.register(processorWithPriority(MEDIUM));
-        registry.register(processorWithPriority(LOW));
-        registry.register(processorWithPriority(HIGHEST));
+        PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
+                processorWithPriority(MEDIUM),
+                processorWithPriority(LOW),
+                processorWithPriority(HIGHEST)));
 
         registry.applyPostProcessing(badRequestProblem(), simpleContext());
 
@@ -33,10 +33,11 @@ class PostProcessorsRegistryTest {
 
     @Test
     void shouldTolerateDuplicates() {
-        registry.register(processorWithPriority(MEDIUM));
-        registry.register(processorWithPriority(HIGHEST));
-        registry.register(processorWithPriority(MEDIUM));
-        registry.register(processorWithPriority(MEDIUM));
+        PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
+                processorWithPriority(MEDIUM),
+                processorWithPriority(HIGHEST),
+                processorWithPriority(MEDIUM),
+                processorWithPriority(MEDIUM)));
 
         registry.applyPostProcessing(badRequestProblem(), simpleContext());
 

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapperTest.java
@@ -2,15 +2,22 @@ package io.quarkiverse.httpproblem.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkus.security.AuthenticationCompletionException;
 
 class AuthenticationCompletionExceptionMapperTest {
 
-    AuthenticationCompletionExceptionMapper mapper = new AuthenticationCompletionExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    AuthenticationCompletionExceptionMapper mapper = new AuthenticationCompletionExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp401() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapperTest.java
@@ -3,22 +3,24 @@ package io.quarkiverse.httpproblem.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
 class AuthenticationFailedExceptionMapperTest {
 
-    AuthenticationFailedExceptionMapper mapper = new AuthenticationFailedExceptionMapper();
-
-    @BeforeEach
-    void setup() {
-        mapper.currentVertxRequest = mock(CurrentVertxRequest.class);
-    }
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    CurrentVertxRequest currentVertxRequest = mock(CurrentVertxRequest.class);
+    AuthenticationFailedExceptionMapper mapper = new AuthenticationFailedExceptionMapper(registry, currentVertxRequest);
 
     @Test
     void shouldProduceHttp401() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapperTest.java
@@ -2,16 +2,23 @@ package io.quarkiverse.httpproblem.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkus.security.AuthenticationRedirectException;
 
 class AuthenticationRedirectExceptionMapperTest {
 
-    AuthenticationRedirectExceptionMapper mapper = new AuthenticationRedirectExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    AuthenticationRedirectExceptionMapper mapper = new AuthenticationRedirectExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp302WithAllNeededHeaders() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapperTest.java
@@ -2,15 +2,22 @@ package io.quarkiverse.httpproblem.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkus.security.ForbiddenException;
 
 class ForbiddenExceptionMapperTest {
 
-    ForbiddenExceptionMapper mapper = new ForbiddenExceptionMapper();
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    ForbiddenExceptionMapper mapper = new ForbiddenExceptionMapper(registry);
 
     @Test
     void shouldProduceHttp403() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapperTest.java
@@ -3,22 +3,24 @@ package io.quarkiverse.httpproblem.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
+
 import jakarta.ws.rs.core.Response;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
 class UnauthorizedExceptionMapperTest {
 
-    UnauthorizedExceptionMapper mapper = new UnauthorizedExceptionMapper();
-
-    @BeforeEach
-    void setup() {
-        mapper.currentVertxRequest = mock(CurrentVertxRequest.class);
-    }
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    CurrentVertxRequest currentVertxRequest = mock(CurrentVertxRequest.class);
+    UnauthorizedExceptionMapper mapper = new UnauthorizedExceptionMapper(registry, currentVertxRequest);
 
     @Test
     void shouldProduceHttp401() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapperTest.java
@@ -49,6 +49,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
 import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
 class ConstraintViolationExceptionMapperTest {
 
@@ -57,7 +60,11 @@ class ConstraintViolationExceptionMapperTest {
     final String VALID = "aaaaaaa";
     final String TOO_SHORT_COMPANY_NAME = "CO";
 
-    final ConstraintViolationExceptionMapper mapper = new ConstraintViolationExceptionMapper();
+    final PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+    final ConstraintViolationConfig constraintViolationConfig = new ConstraintViolationConfig(400, "Bad Request");
+    final ConstraintViolationExceptionMapper mapper = new ConstraintViolationExceptionMapper(registry,
+            constraintViolationConfig);
     final StubResourceInfo resourceInfo = StubResourceInfo.withDefaultValidator();
 
     @BeforeEach
@@ -205,7 +212,8 @@ class ConstraintViolationExceptionMapperTest {
         Set<ConstraintViolation<ProgrammaticTestBean>> violations = validator.validate(bean);
         ConstraintViolationException exception = new ConstraintViolationException(violations);
 
-        ConstraintViolationExceptionMapper resourceInfoLessMapper = new ConstraintViolationExceptionMapper();
+        ConstraintViolationExceptionMapper resourceInfoLessMapper = new ConstraintViolationExceptionMapper(registry,
+                constraintViolationConfig);
         resourceInfoLessMapper.resourceInfo = null;
 
         List<Violation> mappedViolations = mapAndExtractViolations(exception, resourceInfoLessMapper);
@@ -229,7 +237,8 @@ class ConstraintViolationExceptionMapperTest {
         Set<ConstraintViolation<ProgrammaticNestedTestBean>> violations = validator.validate(bean);
         ConstraintViolationException exception = new ConstraintViolationException(violations);
 
-        ConstraintViolationExceptionMapper resourceInfoLessMapper = new ConstraintViolationExceptionMapper();
+        ConstraintViolationExceptionMapper resourceInfoLessMapper = new ConstraintViolationExceptionMapper(registry,
+                constraintViolationConfig);
         resourceInfoLessMapper.resourceInfo = null;
 
         List<Violation> mappedViolations = mapAndExtractViolations(exception, resourceInfoLessMapper);
@@ -280,7 +289,8 @@ class ConstraintViolationExceptionMapperTest {
                 .validateParameters(impl, implMethod, new Object[] { "short" });
         ConstraintViolationException exception = new ConstraintViolationException(constraintViolations);
 
-        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper();
+        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper(registry,
+                constraintViolationConfig);
         testMapper.resourceInfo = new ResourceInfo() {
             @Override
             public Method getResourceMethod() {
@@ -526,7 +536,8 @@ class ConstraintViolationExceptionMapperTest {
                 .validateParameters(resource, method, args);
         ConstraintViolationException exception = new ConstraintViolationException(violations);
 
-        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper();
+        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper(registry,
+                constraintViolationConfig);
         testMapper.resourceInfo = new ResourceInfo() {
             @Override
             public Method getResourceMethod() {
@@ -575,7 +586,8 @@ class ConstraintViolationExceptionMapperTest {
                 .validateParameters(resource, method, new Object[] { beanParam });
         ConstraintViolationException exception = new ConstraintViolationException(violations);
 
-        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper();
+        ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper(registry,
+                constraintViolationConfig);
         testMapper.resourceInfo = new ResourceInfo() {
             @Override
             public Method getResourceMethod() {
@@ -625,69 +637,4 @@ class ConstraintViolationExceptionMapperTest {
         }
     }
 
-    /**
-     * Verifies that configure() and toProblem() are atomic: no request can ever see a status from one
-     * configure() call paired with a title from another configure() call.
-     */
-    @Test
-    void configurationIsAlwaysReadAtomically() throws InterruptedException {
-        final int iterations = 10_000;
-        final ConstraintViolationExceptionMapper testMapper = new ConstraintViolationExceptionMapper();
-        final ConstraintViolationException exception = new ConstraintViolationException("test", null);
-
-        final java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
-        final java.util.concurrent.CountDownLatch doneLatch = new java.util.concurrent.CountDownLatch(2);
-        final java.util.List<HttpValidationProblem> results = new java.util.concurrent.CopyOnWriteArrayList<>();
-
-        // Writer thread: alternates between two consistent (status, title) pairs
-        Thread writer = new Thread(() -> {
-            try {
-                startLatch.await();
-                for (int i = 0; i < iterations; i++) {
-                    if (i % 2 == 0) {
-                        ConstraintViolationExceptionMapper.configure(422, "Constraint violation");
-                    } else {
-                        ConstraintViolationExceptionMapper.configure(400, "Bad Request");
-                    }
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } finally {
-                doneLatch.countDown();
-            }
-        });
-
-        // Reader thread: calls toProblem() and collects results
-        Thread reader = new Thread(() -> {
-            try {
-                startLatch.await();
-                for (int i = 0; i < iterations; i++) {
-                    results.add(testMapper.toProblem(exception));
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } finally {
-                doneLatch.countDown();
-            }
-        });
-
-        writer.start();
-        reader.start();
-        startLatch.countDown(); // release both threads at the same instant
-        doneLatch.await();
-
-        // Reset to default so other tests are unaffected
-        ConstraintViolationExceptionMapper.configure(400, "Bad Request");
-
-        // Every result must have a self-consistent (status, title) pair — never a torn read
-        for (HttpValidationProblem problem : results) {
-            int status = problem.getStatusCode();
-            String actualTitle = problem.getTitle();
-            boolean isDefaultPair = status == 400 && "Bad Request".equals(actualTitle);
-            boolean isCustomPair = status == 422 && "Constraint violation".equals(actualTitle);
-            assertThat(isDefaultPair || isCustomPair)
-                    .as("Torn read detected: status=%d title='%s'", status, actualTitle)
-                    .isTrue();
-        }
-    }
 }


### PR DESCRIPTION
- Convert PostProcessorsRegistry from a static singleton to a CDI bean.
- Replace CDI.current() lookups and static volatile config in all exception mappers with constructor injection.
- Synthetic beans are now registered during STATIC_INIT so they're available when RESTEasy Classic validates providers.
- No-arg constructors retained for RESTEasy Classic compatibility