### PR TITLE
Add build-time config to disable specific built-in exception mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,20 @@ Content-Type: application/problem+json
 }
 ```
 
+- (Build time) Disable specific built-in exception mappers. The key is the exception class simple name in kebab-case.
+
+```
+quarkus.http-problem.mapper.not-found-exception.enabled=false
+quarkus.http-problem.mapper.web-application-exception.enabled=false
+```
+
+When a mapper is disabled, the exception will not be converted to `application/problem+json` and will fall through to the default Quarkus error handling.
+
+Available mapper keys: `http-problem`, `web-application-exception`, `forbidden-exception`, `not-found-exception`, `unauthorized-exception`, 
+`authentication-failed-exception`, `authentication-redirect-exception`, `authentication-completion-exception`, `validation-exception`, 
+`constraint-violation-exception`, `json-processing-exception`, `unrecognized-property-exception`, `invalid-format-exception`, 
+`processing-exception`, `jsonb-exception`, `throwable-problem`, `exception`.
+
 - (Runtime) Tuning logging
 
 ```

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.httpproblem.deployment;
 
+import java.util.Map;
 import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -39,6 +40,27 @@ public interface ProblemBuildConfig {
         @WithName("validation-problem-schema")
         @WithDefault("HttpValidationProblem")
         String validationProblemSchema();
+    }
+
+    /**
+     * Per-mapper configuration, keyed by exception simple name in kebab-case
+     * (e.g. {@code web-application-exception}, {@code not-found-exception}).
+     * <p>
+     * Use this to disable specific built-in exception mappers:
+     *
+     * <pre>
+     * quarkus.http-problem.mapper.not-found-exception.enabled=false
+     * </pre>
+     */
+    @WithName("mapper")
+    Map<String, MapperConfig> mapper();
+
+    interface MapperConfig {
+        /**
+         * Whether the mapper for this exception type should be registered.
+         */
+        @WithDefault("true")
+        boolean enabled();
     }
 
     /**

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -6,6 +6,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,7 +49,9 @@ public class ProblemProcessor {
             "io.quarkus.resteasy.json",
             "io.quarkus.resteasy-json");
 
-    private static List<ExceptionMapperDefinition> neededExceptionMappers() {
+    private static List<ExceptionMapperDefinition> neededExceptionMappers(ProblemBuildConfig config) {
+        Map<String, ProblemBuildConfig.MapperConfig> mapperConfig = config.mapper();
+
         Stream<ExceptionMapperDefinition> allMappers = Stream.of(
                 mapper(EXTENSION_MAIN_PACKAGE + "HttpProblemMapper")
                         .thatHandles(EXTENSION_MAIN_PACKAGE + "HttpProblem"),
@@ -103,7 +106,26 @@ public class ProblemProcessor {
 
         return allMappers
                 .filter(ExceptionMapperDefinition::isNeeded)
+                .filter(mapper -> isMapperEnabled(mapper.exceptionClassName, mapperConfig))
                 .collect(Collectors.toList());
+    }
+
+    static boolean isMapperEnabled(String exceptionClassName, Map<String, ProblemBuildConfig.MapperConfig> mapperConfig) {
+        String key = toKebabCase(exceptionClassName.substring(exceptionClassName.lastIndexOf('.') + 1));
+        ProblemBuildConfig.MapperConfig cfg = mapperConfig.get(key);
+        return cfg == null || cfg.enabled();
+    }
+
+    static String toKebabCase(String simpleName) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < simpleName.length(); i++) {
+            char c = simpleName.charAt(i);
+            if (Character.isUpperCase(c) && i > 0) {
+                result.append('-');
+            }
+            result.append(Character.toLowerCase(c));
+        }
+        return result.toString();
     }
 
     @BuildStep
@@ -116,14 +138,14 @@ public class ProblemProcessor {
     }
 
     @BuildStep(onlyIf = RestEasyClassicDetector.class)
-    void registerMappersForClassic(BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-        neededExceptionMappers().forEach(mapper -> providers.produce(
+    void registerMappersForClassic(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, ProblemBuildConfig config) {
+        neededExceptionMappers(config).forEach(mapper -> providers.produce(
                 new ResteasyJaxrsProviderBuildItem(mapper.mapperClassName)));
     }
 
     @BuildStep(onlyIf = RestEasyReactiveDetector.class)
-    void registerMappersForReactive(BuildProducer<ExceptionMapperBuildItem> providers) {
-        neededExceptionMappers().forEach(mapper -> providers.produce(
+    void registerMappersForReactive(BuildProducer<ExceptionMapperBuildItem> providers, ProblemBuildConfig config) {
+        neededExceptionMappers(config).forEach(mapper -> providers.produce(
                 new ExceptionMapperBuildItem(mapper.mapperClassName,
                         mapper.exceptionClassName, Priorities.AUTHENTICATION - 1, true)));
     }
@@ -132,11 +154,18 @@ public class ProblemProcessor {
     // asynchronous challenge/response resolution (Uni<Response>). These classes therefore use
     // @ServerExceptionMapper methods (not JAX-RS ExceptionMapper<T> providers) and must be registered as custom mappers.
     @BuildStep(onlyIf = RestEasyReactiveDetector.class)
-    void registerCustomExceptionMappers(BuildProducer<CustomExceptionMapperBuildItem> customExceptionMapper) {
-        customExceptionMapper.produce(
-                new CustomExceptionMapperBuildItem(EXTENSION_MAIN_PACKAGE + "security.UnauthorizedExceptionReactiveMapper"));
-        customExceptionMapper.produce(new CustomExceptionMapperBuildItem(
-                EXTENSION_MAIN_PACKAGE + "security.AuthenticationFailedExceptionReactiveMapper"));
+    void registerCustomExceptionMappers(BuildProducer<CustomExceptionMapperBuildItem> customExceptionMapper,
+            ProblemBuildConfig config) {
+        Map<String, ProblemBuildConfig.MapperConfig> mapperConfig = config.mapper();
+        if (isMapperEnabled("io.quarkus.security.UnauthorizedException", mapperConfig)) {
+            customExceptionMapper.produce(
+                    new CustomExceptionMapperBuildItem(
+                            EXTENSION_MAIN_PACKAGE + "security.UnauthorizedExceptionReactiveMapper"));
+        }
+        if (isMapperEnabled("io.quarkus.security.AuthenticationFailedException", mapperConfig)) {
+            customExceptionMapper.produce(new CustomExceptionMapperBuildItem(
+                    EXTENSION_MAIN_PACKAGE + "security.AuthenticationFailedExceptionReactiveMapper"));
+        }
     }
 
     @BuildStep(onlyIf = JacksonDetector.class)

--- a/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
@@ -7,8 +7,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 
 import io.quarkus.deployment.Capabilities;
@@ -49,6 +52,46 @@ class ProblemProcessorTest {
 
         verify(logger).error("`quarkus-http-problem` extension is useless without json provider. "
                 + "Please add `quarkus-rest-jackson` or `quarkus-rest-jsonb` (or classic `resteasy` equivalent) extension to your project.");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "WebApplicationException, web-application-exception",
+            "NotFoundException, not-found-exception",
+            "ForbiddenException, forbidden-exception",
+            "HttpProblem, http-problem",
+            "UnauthorizedException, unauthorized-exception",
+            "AuthenticationFailedException, authentication-failed-exception",
+            "ConstraintViolationException, constraint-violation-exception",
+            "JsonProcessingException, json-processing-exception",
+            "Exception, exception"
+    })
+    void toKebabCaseShouldConvertClassNamesCorrectly(String input, String expected) {
+        assertThat(ProblemProcessor.toKebabCase(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void isMapperEnabledShouldReturnTrueWhenNoConfigPresent() {
+        assertThat(ProblemProcessor.isMapperEnabled("jakarta.ws.rs.NotFoundException", Map.of()))
+                .isTrue();
+    }
+
+    @Test
+    void isMapperEnabledShouldReturnFalseWhenDisabled() {
+        ProblemBuildConfig.MapperConfig disabled = () -> false;
+        Map<String, ProblemBuildConfig.MapperConfig> config = Map.of("not-found-exception", disabled);
+
+        assertThat(ProblemProcessor.isMapperEnabled("jakarta.ws.rs.NotFoundException", config))
+                .isFalse();
+    }
+
+    @Test
+    void isMapperEnabledShouldReturnTrueWhenExplicitlyEnabled() {
+        ProblemBuildConfig.MapperConfig enabled = () -> true;
+        Map<String, ProblemBuildConfig.MapperConfig> config = Map.of("not-found-exception", enabled);
+
+        assertThat(ProblemProcessor.isMapperEnabled("jakarta.ws.rs.NotFoundException", config))
+                .isTrue();
     }
 
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperIT.java
@@ -1,0 +1,53 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(DisabledMapperIT.WebApplicationExceptionMapperDisabled.class)
+class DisabledMapperIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void disabledMapperShouldFallThroughToDefaultExceptionMapper() {
+        // WebApplicationException(400) would normally be handled by WebApplicationExceptionMapper
+        // and return 400. With it disabled, DefaultExceptionMapper catches it as Exception -> 500.
+        given()
+                .queryParam("status", 400)
+                .get("/throw/jax-rs/web-application-exception")
+                .then()
+                .statusCode(500)
+                .body("title", equalTo("Internal Server Error"))
+                .body("status", equalTo(500));
+    }
+
+    @Test
+    void notFoundExceptionMapperShouldStillWork() {
+        given()
+                .queryParam("message", "not here")
+                .get("/throw/jax-rs/not-found-exception")
+                .then()
+                .statusCode(404)
+                .body("title", equalTo("Not Found"))
+                .body("detail", equalTo("not here"));
+    }
+
+    public static class WebApplicationExceptionMapperDisabled implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http-problem.mapper.web-application-exception.enabled", "false");
+        }
+    }
+}


### PR DESCRIPTION
Users who want to handle specific exceptions with their own mapper had no way to prevent the built-in one from registering. This adds a per-mapper `enabled` flag keyed by the exception's simple name in kebab-case:

```
quarkus.http-problem.mapper.web-application-exception.enabled=false
quarkus.http-problem.mapper.not-found-exception.enabled=false
```

Disabled mappers are excluded at build time from both RESTEasy classic and reactive registration paths, including the custom reactive mappers for UnauthorizedException and AuthenticationFailedException.