### PR TITLE
Sanitize JSON mapper detail field to prevent leaking internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,25 @@ Content-Type: application/problem+json
 }
 ```
 
+- (Build time) Include raw exception messages in the detail field of JSON parsing/binding error responses. Disabled by default to prevent leaking internal class names and implementation details.
+
+```
+quarkus.http-problem.include-details=false
+```
+
+Result (malformed JSON POST):
+
+```json
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+    "status": 400,
+    "title": "Bad Request",
+    "detail": "Malformed request body"
+}
+```
+
 - (Build time) Disable specific built-in exception mappers. The key is the exception class simple name in kebab-case.
 
 ```

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
@@ -14,6 +14,14 @@ import io.smallrye.config.WithName;
 public interface ProblemBuildConfig {
 
     /**
+     * When enabled, JSON parsing/binding exception mappers include the raw exception message
+     * in the problem detail field. When disabled (the default), a generic message is used
+     * to avoid leaking internal class names and implementation details.
+     */
+    @WithDefault("false")
+    boolean includeDetails();
+
+    /**
      * MDC properties that should be included in problem responses.
      */
     @WithDefault("uuid")

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersIT.java
@@ -3,13 +3,14 @@ package io.quarkiverse.httpproblem;
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.oneOf;
 
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,14 +24,7 @@ import java.io.IOException;
 @QuarkusTest
 class JsonMappersIT {
 
-    static final String JACKSON_MALFORMED_PAYLOAD_DETAIL = "Unexpected end-of-input within/between Object entries";
-    static final String JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL = "Cannot deserialize value of type `java.util.UUID` from String \"ABC-DEF-GHI\": UUID has to be represented by standard 36-char representation";
-
-    static final String JSONB_CLASSIC_MALFORMED_PAYLOAD_DETAIL = "Internal error: Invalid token=EOF at (line no=1, column no=14, offset=13). Expected tokens are: [CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]";
-    static final String JSONB_REACTIVE_MALFORMED_PAYLOAD_DETAIL = "Invalid token=EOF at (line no=1, column no=14, offset=13). Expected tokens are: [CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]";
-    static final String JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL = "Internal error: Invalid UUID string: ABC-DEF-GHI";
-    static final String JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL = "Invalid UUID string: ABC-DEF-GHI";
-    static final String QUARKUS_2_15_JACKSON_REACTIVE_ERROR_DETAIL = "HTTP 400 Bad Request";
+    static final String SANITIZED_DETAIL = "Malformed request body";
 
     private static final Logger logger = LoggerFactory.getLogger(JsonMappersIT.class);
 
@@ -39,31 +33,35 @@ class JsonMappersIT {
     }
 
     @Test
-    @DisplayName("Should return Bad Request(400) when request payload is malformed #1")
+    @DisplayName("Should return Bad Request(400) without leaking internals when request payload is malformed")
     void shouldThrowBadRequestOnMalformedBody() {
-        given()
+        ExtractableResponse<Response> response = given()
                 .body("{\"key\":\"")
                 .contentType(APPLICATION_JSON)
                 .post("/throw/json")
                 .then()
-                .statusCode(BAD_REQUEST.getStatusCode());
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .extract();
+
+        assertDetailDoesNotLeakInternals(response);
     }
 
     @Test
-    @DisplayName("Should return Bad Request(400) when request payload is malformed #2")
-    @Disabled("TEMPORARY DISABLED")
+    @DisplayName("Should return Bad Request(400) without leaking internals for differently malformed body")
     void shouldThrowBadRequestOnDifferentlyMalformedBody() {
-        given()
+        ExtractableResponse<Response> response = given()
                 .body("{\"key\":")
                 .contentType(APPLICATION_JSON)
                 .post("/throw/json")
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
-                .body("detail", oneOf(JACKSON_MALFORMED_PAYLOAD_DETAIL, JSONB_CLASSIC_MALFORMED_PAYLOAD_DETAIL, JSONB_REACTIVE_MALFORMED_PAYLOAD_DETAIL, QUARKUS_2_15_JACKSON_REACTIVE_ERROR_DETAIL));
+                .extract();
+
+        assertDetailDoesNotLeakInternals(response);
     }
 
     @Test
-    @DisplayName("Should return Bad Request(400) when field in payload cannot be deserialized")
+    @DisplayName("Should return Bad Request(400) with sanitized detail when field cannot be deserialized")
     void shouldThrowBadRequestForInvalidFieldFormat() throws IOException {
         ValidatableResponse response = given()
                 .body("{\"uuid_field_1\":\"ABC-DEF-GHI\"}")
@@ -72,20 +70,17 @@ class JsonMappersIT {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
 
-        /**
-         *  @see io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader, line 55
-         */
-        if(response.extract().body().asInputStream().available() == 0) {
+        if (response.extract().body().asInputStream().available() == 0) {
             logger.info("Reactive impl returns empty body, skipping further validation");
             return;
         }
 
-        response.body("detail", oneOf(JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL))
-                .body("field", anyOf(is("uuid_field_1"), nullValue())); // field not available in jsonb impl
+        response.body("detail", is(SANITIZED_DETAIL))
+                .body("field", anyOf(is("uuid_field_1"), nullValue()));
     }
 
     @Test
-    @DisplayName("Should return Bad Request(400) when nested field in payload cannot be deserialized")
+    @DisplayName("Should return Bad Request(400) with sanitized detail for nested field deserialization error")
     void shouldThrowBadRequestForInvalidFieldFormatInNestedObject() throws IOException {
         ValidatableResponse response = given()
                 .body("{\"nested\": {\"uuid_field_2\":\"ABC-DEF-GHI\"}}")
@@ -94,21 +89,17 @@ class JsonMappersIT {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
 
-        /**
-         *  @see io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader, line 55
-         */
-        if(response.extract().body().asInputStream().available() == 0) {
+        if (response.extract().body().asInputStream().available() == 0) {
             logger.info("Reactive impl returns empty body, skipping further validation");
             return;
         }
 
-        response.body("detail", oneOf(JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL))
-                .body("field", anyOf(is("nested.uuid_field_2"), nullValue())); // field not available in jsonb impl
+        response.body("detail", is(SANITIZED_DETAIL))
+                .body("field", anyOf(is("nested.uuid_field_2"), nullValue()));
     }
 
-
     @Test
-    @DisplayName("Should return Bad Request(400) when field in payload collection item cannot be deserialized #3")
+    @DisplayName("Should return Bad Request(400) with sanitized detail for collection item deserialization error")
     void shouldThrowBadRequestForInvalidFieldFormatInCollectionItem() throws IOException {
         ValidatableResponse response = given()
                 .body("{\"collection\": [{\"uuid_field_2\":\"ABC-DEF-GHI\"}]}")
@@ -117,15 +108,27 @@ class JsonMappersIT {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
 
-        /**
-         *  @see io.quarkus.resteasy.reactive.jackson.runtime.serialisers.JacksonMessageBodyReader, line 55
-         */
-        if(response.extract().body().asInputStream().available() == 0) {
+        if (response.extract().body().asInputStream().available() == 0) {
             logger.info("Reactive impl returns empty body, skipping further validation");
             return;
         }
 
-        response.body("detail", oneOf(JACKSON_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_CLASSIC_FIELD_SERIALIZATION_ERROR_DETAIL, JSONB_REACTIVE_FIELD_SERIALIZATION_ERROR_DETAIL))
+        response.body("detail", is(SANITIZED_DETAIL))
                 .body("field", anyOf(is("collection[0].uuid_field_2"), nullValue()));
+    }
+
+    private static void assertDetailDoesNotLeakInternals(ExtractableResponse<Response> response) {
+        String contentType = response.contentType();
+        if (contentType == null || !contentType.contains("json")) {
+            // RESTEasy Reactive returned plain text — no JSON to check
+            return;
+        }
+        String detail = response.body().jsonPath().getString("detail");
+        if (detail != null) {
+            assertThat(detail)
+                    .as("detail must not leak internal class names or stack traces")
+                    .doesNotContain("com.", "org.", "java.", "jakarta.")
+                    .doesNotContain("Exception", "adapting object");
+        }
     }
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersIT.java
@@ -1,0 +1,89 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+
+@QuarkusTest
+@TestProfile(UnsanitizedJsonMappersIT.SanitizationDisabled.class)
+class UnsanitizedJsonMappersIT {
+
+    static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private static final Logger logger = LoggerFactory.getLogger(UnsanitizedJsonMappersIT.class);
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    @DisplayName("Should expose raw detail when include-details is true")
+    void shouldExposeRawDetailOnMalformedBody() {
+        ExtractableResponse<Response> response = given()
+                .body("{\"key\":\"")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/json")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .extract();
+
+        if (isProblemJson(response)) {
+            assertThat(response.body().jsonPath().getString("detail")).isNotEqualTo(SANITIZED_DETAIL);
+        } else {
+            logger.info("Response handled by RESTEasy Reactive before mapper, skipping detail assertion");
+        }
+    }
+
+    @Test
+    @DisplayName("Should expose raw detail for invalid field format when include-details is true")
+    void shouldExposeRawDetailForInvalidFieldFormat() throws IOException {
+        ValidatableResponse response = given()
+                .body("{\"uuid_field_1\":\"ABC-DEF-GHI\"}")
+                .contentType(APPLICATION_JSON)
+                .post("/throw/json")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode());
+
+        if (response.extract().body().asInputStream().available() == 0) {
+            logger.info("Reactive impl returns empty body, skipping further validation");
+            return;
+        }
+
+        response.body("detail", not(is(SANITIZED_DETAIL)))
+                .body("field", anyOf(is("uuid_field_1"), nullValue()));
+    }
+
+    private static boolean isProblemJson(ExtractableResponse<Response> response) {
+        String contentType = response.contentType();
+        return contentType != null && contentType.contains("application/problem+json");
+    }
+
+    public static class SanitizationDisabled implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http-problem.include-details", "true");
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapper.java
@@ -8,6 +8,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
@@ -21,20 +23,30 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 @Priority(Priorities.USER)
 public final class InvalidFormatExceptionMapper extends ExceptionMapperBase<InvalidFormatException> {
 
+    static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private final boolean includeDetails;
+
     public InvalidFormatExceptionMapper() {
+        this.includeDetails = false;
     }
 
     @Inject
-    public InvalidFormatExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+    public InvalidFormatExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            @ConfigProperty(name = "quarkus.http-problem.include-details", defaultValue = "false") boolean includeDetails) {
         super(postProcessorsRegistry);
+        this.includeDetails = includeDetails;
     }
 
     @Override
     protected HttpProblem toProblem(InvalidFormatException exception) {
+        String detail = includeDetails
+                ? exception.getOriginalMessage()
+                : SANITIZED_DETAIL;
         return HttpProblem.builder()
                 .withStatus(Response.Status.BAD_REQUEST)
                 .withTitle(Response.Status.BAD_REQUEST.getReasonPhrase())
-                .withDetail(exception.getOriginalMessage())
+                .withDetail(detail)
                 .with("field", serializePath(exception.getPath()))
                 .build();
     }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
@@ -6,6 +6,8 @@ import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
@@ -18,16 +20,26 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 @Priority(Priorities.USER)
 public final class JsonProcessingExceptionMapper extends ExceptionMapperBase<JsonProcessingException> {
 
+    static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private final boolean includeDetails;
+
     public JsonProcessingExceptionMapper() {
+        this.includeDetails = false;
     }
 
     @Inject
-    public JsonProcessingExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+    public JsonProcessingExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            @ConfigProperty(name = "quarkus.http-problem.include-details", defaultValue = "false") boolean includeDetails) {
         super(postProcessorsRegistry);
+        this.includeDetails = includeDetails;
     }
 
     @Override
     protected HttpProblem toProblem(JsonProcessingException exception) {
-        return HttpProblem.valueOf(BAD_REQUEST, exception.getOriginalMessage());
+        String detail = includeDetails
+                ? exception.getOriginalMessage()
+                : SANITIZED_DETAIL;
+        return HttpProblem.valueOf(BAD_REQUEST, detail);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
@@ -7,6 +7,8 @@ import jakarta.inject.Inject;
 import jakarta.json.bind.JsonbException;
 import jakarta.ws.rs.Priorities;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
@@ -14,16 +16,26 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 @Priority(Priorities.USER)
 public final class JsonbExceptionMapper extends ExceptionMapperBase<JsonbException> {
 
+    static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private final boolean includeDetails;
+
     public JsonbExceptionMapper() {
+        this.includeDetails = false;
     }
 
     @Inject
-    public JsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+    public JsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            @ConfigProperty(name = "quarkus.http-problem.include-details", defaultValue = "false") boolean includeDetails) {
         super(postProcessorsRegistry);
+        this.includeDetails = includeDetails;
     }
 
     @Override
     protected HttpProblem toProblem(JsonbException exception) {
+        if (!includeDetails) {
+            return HttpProblem.valueOf(BAD_REQUEST, SANITIZED_DETAIL);
+        }
         return HttpProblem.valueOf(BAD_REQUEST, exception.getCause() == null ? null : exception.getCause().getMessage());
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
@@ -8,6 +8,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ProcessingException;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
@@ -15,12 +17,19 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 @Priority(Priorities.USER)
 public final class RestEasyClassicJsonbExceptionMapper extends ExceptionMapperBase<ProcessingException> {
 
+    static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private final boolean includeDetails;
+
     public RestEasyClassicJsonbExceptionMapper() {
+        this.includeDetails = false;
     }
 
     @Inject
-    public RestEasyClassicJsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry) {
+    public RestEasyClassicJsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            @ConfigProperty(name = "quarkus.http-problem.include-details", defaultValue = "false") boolean includeDetails) {
         super(postProcessorsRegistry);
+        this.includeDetails = includeDetails;
     }
 
     /**
@@ -33,7 +42,10 @@ public final class RestEasyClassicJsonbExceptionMapper extends ExceptionMapperBa
     protected HttpProblem toProblem(ProcessingException exception) {
         if (exception.getCause() != null
                 && exception.getCause().getClass().getName().equals("jakarta.json.bind.JsonbException")) {
-            return HttpProblem.valueOf(BAD_REQUEST, exception.getCause().getMessage());
+            String detail = includeDetails
+                    ? exception.getCause().getMessage()
+                    : SANITIZED_DETAIL;
+            return HttpProblem.valueOf(BAD_REQUEST, detail);
         } else {
             return HttpProblem.valueOf(INTERNAL_SERVER_ERROR);
         }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
@@ -22,7 +22,7 @@ class InvalidFormatExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
             List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
-    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry);
+    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry, true);
 
     @Test
     void shouldProduceHttp400WithFieldInfo() {
@@ -62,6 +62,33 @@ class InvalidFormatExceptionMapperTest {
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
                 .hasFieldOrPropertyWithValue("parameters.field", "?");
+    }
+
+    @Test
+    void shouldSanitizeDetailByDefault() {
+        InvalidFormatExceptionMapper sanitizedMapper = new InvalidFormatExceptionMapper(registry, false);
+        InvalidFormatException exception = buildExceptionWithPath(
+                new JsonMappingException.Reference(this, "customFieldName"));
+
+        Response response = sanitizedMapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", InvalidFormatExceptionMapper.SANITIZED_DETAIL)
+                .hasFieldOrPropertyWithValue("parameters.field", "customFieldName");
+    }
+
+    @Test
+    void shouldPreserveDetailWhenIncludeDetails() {
+        InvalidFormatException exception = buildExceptionWithPath(
+                new JsonMappingException.Reference(this, "customFieldName"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field");
     }
 
     private InvalidFormatException buildExceptionWithPath(JsonMappingException.Reference... pathSegments) {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.httpproblem.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
+class JsonProcessingExceptionMapperTest {
+
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+
+    @Test
+    void shouldProduceHttp400WithOriginalMessageWhenIncludeDetails() {
+        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, true);
+        JsonParseException exception = new JsonParseException("Unexpected end-of-input");
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getMediaType()).isEqualTo(HttpProblem.MEDIA_TYPE);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Unexpected end-of-input");
+    }
+
+    @Test
+    void shouldSanitizeDetailByDefault() {
+        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, false);
+        JsonParseException exception = new JsonParseException("Unexpected end-of-input");
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", JsonProcessingExceptionMapper.SANITIZED_DETAIL);
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
@@ -1,0 +1,73 @@
+package io.quarkiverse.httpproblem.jsonb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.json.bind.JsonbException;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+
+class JsonbExceptionMapperTest {
+
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(
+            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+
+    @Test
+    void shouldProduceHttp400WithCauseMessageWhenIncludeDetails() {
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, true);
+        JsonbException exception = new JsonbException("wrapper", new RuntimeException("Invalid UUID string: ABC"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getMediaType()).isEqualTo(HttpProblem.MEDIA_TYPE);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Invalid UUID string: ABC");
+    }
+
+    @Test
+    void shouldSanitizeDetailByDefault() {
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, false);
+        JsonbException exception = new JsonbException("wrapper", new RuntimeException("Invalid UUID string: ABC"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", JsonbExceptionMapper.SANITIZED_DETAIL);
+    }
+
+    @Test
+    void shouldPreserveDetailWhenIncludeDetails() {
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, true);
+        JsonbException exception = new JsonbException("wrapper", new RuntimeException("Internal error details"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Internal error details");
+    }
+
+    @Test
+    void shouldSanitizeEvenWithNoCause() {
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, false);
+        JsonbException exception = new JsonbException("wrapper");
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", JsonbExceptionMapper.SANITIZED_DETAIL);
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
@@ -18,7 +19,7 @@ class RestEasyClassicJsonbExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
             List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
-    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry);
+    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry, true);
 
     @Test
     void processingExceptionShouldProduceHttp500() {
@@ -36,5 +37,29 @@ class RestEasyClassicJsonbExceptionMapperTest {
         Response response = mapper.toResponse(exception);
 
         assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void shouldSanitizeDetailByDefault() {
+        RestEasyClassicJsonbExceptionMapper sanitizedMapper = new RestEasyClassicJsonbExceptionMapper(registry, false);
+        ProcessingException exception = new ProcessingException(new JsonbException("Internal class details leaked"));
+
+        Response response = sanitizedMapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", RestEasyClassicJsonbExceptionMapper.SANITIZED_DETAIL);
+    }
+
+    @Test
+    void shouldPreserveDetailWhenIncludeDetails() {
+        ProcessingException exception = new ProcessingException(new JsonbException("Something is wrong"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertThat(response.getEntity())
+                .isInstanceOf(HttpProblem.class)
+                .hasFieldOrPropertyWithValue("detail", "Something is wrong");
     }
 }


### PR DESCRIPTION
 
  - Add build-time config property `quarkus.http-problem.include-details` (default false) that controls whether exception mappers expose raw exception messages in the `detail` field
  - When disabled, mappers return "Malformed request body" instead of raw messages that can leak internal class names, adapter names, and implementation structure (Following OWASP Improper Error Handling recommendations)
  - Set quarkus.http-problem.include-details=true to restore the previous behavior for debugging

---

- Fixes: #365

N.B. This is a breaking change in behavior. However, we should not leak implementation details by default. 