### PR TITLE
Publish core integration tests for Quarkus Platform

### DIFF
--- a/integration-test/core/pom.xml
+++ b/integration-test/core/pom.xml
@@ -22,4 +22,20 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ConstraintViolationMapperConfigTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ConstraintViolationMapperConfigTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
-@TestProfile(ConstraintViolationMapperConfigIT.CustomHttpStatus.class)
-class ConstraintViolationMapperConfigIT {
+@TestProfile(ConstraintViolationMapperConfigTest.CustomHttpStatus.class)
+class ConstraintViolationMapperConfigTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperTest.java
@@ -12,8 +12,8 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(DisabledMapperIT.WebApplicationExceptionMapperDisabled.class)
-class DisabledMapperIT {
+@TestProfile(DisabledMapperTest.WebApplicationExceptionMapperDisabled.class)
+class DisabledMapperTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class GenericMappersNativeIT extends GenericMappersIT {
+class GenericMappersNativeIT extends GenericMappersTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersTest.java
@@ -11,7 +11,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class GenericMappersIT {
+class GenericMappersTest {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class JaxRsMappersNativeIT extends JaxRsMappersIT {
+class JaxRsMappersNativeIT extends JaxRsMappersTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class JaxRsMappersIT {
+class JaxRsMappersTest {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class JsonMappersNativeIT extends JsonMappersIT {
+class JsonMappersNativeIT extends JsonMappersTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersTest.java
@@ -22,11 +22,11 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-class JsonMappersIT {
+class JsonMappersTest {
 
     static final String SANITIZED_DETAIL = "Malformed request body";
 
-    private static final Logger logger = LoggerFactory.getLogger(JsonMappersIT.class);
+    private static final Logger logger = LoggerFactory.getLogger(JsonMappersTest.class);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class MdcNativeIT extends MdcIT {
+class MdcNativeIT extends MdcTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcTest.java
@@ -8,7 +8,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class MdcIT {
+class MdcTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class SecurityMappersNativeIT extends SecurityMappersIT {
+class SecurityMappersNativeIT extends SecurityMappersTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import jakarta.ws.rs.core.HttpHeaders;
 
 @QuarkusTest
-class SecurityMappersIT {
+class SecurityMappersTest {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersTest.java
@@ -26,12 +26,12 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-@TestProfile(UnsanitizedJsonMappersIT.SanitizationDisabled.class)
-class UnsanitizedJsonMappersIT {
+@TestProfile(UnsanitizedJsonMappersTest.SanitizationDisabled.class)
+class UnsanitizedJsonMappersTest {
 
     static final String SANITIZED_DETAIL = "Malformed request body";
 
-    private static final Logger logger = LoggerFactory.getLogger(UnsanitizedJsonMappersIT.class);
+    private static final Logger logger = LoggerFactory.getLogger(UnsanitizedJsonMappersTest.class);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class ValidationMappersNativeIT extends ValidationMappersIT {
+class ValidationMappersNativeIT extends ValidationMappersTest {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersTest.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersTest.java
@@ -13,7 +13,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class ValidationMappersIT {
+class ValidationMappersTest {
 
     static final String SAMPLE_DETAIL = "A small one";
     final String TOO_SHORT_NAME = "N";

--- a/integration-test/openapi/pom.xml
+++ b/integration-test/openapi/pom.xml
@@ -22,4 +22,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiNativeIT.java
+++ b/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class OpenApiNativeIT extends OpenApiIT {
+class OpenApiNativeIT extends OpenApiTest {
 }

--- a/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiTest.java
+++ b/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
  * but brackets work fine
  */
 @QuarkusTest
-class OpenApiIT {
+class OpenApiTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -12,6 +12,11 @@
     <name>Quarkus - HTTP-Problem - Integration Tests</name>
     <packaging>pom</packaging>
 
+    <!-- core is always in the reactor so it is published for Quarkus Platform compatibility tests -->
+    <modules>
+        <module>core</module>
+    </modules>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.httpproblem</groupId>
@@ -89,7 +94,6 @@
         <profile>
             <id>it</id>
             <modules>
-                <module>core</module>
                 <module>openapi</module>
                 <module>zalando</module>
                 <module>rest-client</module>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -12,9 +12,18 @@
     <name>Quarkus - HTTP-Problem - Integration Tests</name>
     <packaging>pom</packaging>
 
-    <!-- core is always in the reactor so it is published for Quarkus Platform compatibility tests -->
+    <properties>
+        <!-- we only run the tests when the it profile is enabled -->
+        <skipSurefireTests>true</skipSurefireTests>
+    </properties>
+
+    <!-- we always publish the modules for consumption by the Quarkus Platform -->
     <modules>
         <module>core</module>
+        <module>openapi</module>
+        <module>rest-client</module>
+        <module>zalando</module>
+        <module>tck</module>
     </modules>
 
     <dependencies>
@@ -57,20 +66,10 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>**/*NativeIT.java</exclude>
-                    </excludes>
+                    <skip>${skipSurefireTests}</skip>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
@@ -79,7 +78,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
@@ -93,12 +91,10 @@
     <profiles>
         <profile>
             <id>it</id>
-            <modules>
-                <module>openapi</module>
-                <module>zalando</module>
-                <module>rest-client</module>
-                <module>tck</module>
-            </modules>
+            <properties>
+                <!-- we only run the tests when the it profile is enabled -->
+                <skipSurefireTests>false</skipSurefireTests>
+            </properties>
         </profile>
         <profile>
             <id>jackson</id>
@@ -144,6 +140,7 @@
             <id>native</id>
             <properties>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
+                <skipSurefireTests>true</skipSurefireTests>
             </properties>
 
             <build>

--- a/integration-test/rest-client/pom.xml
+++ b/integration-test/rest-client/pom.xml
@@ -55,4 +55,20 @@
             </dependencies>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientNativeIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem.client;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class RestClientNativeIT extends RestClientIT {
+class RestClientNativeIT extends RestClientTest {
 }

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientTest.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
-class RestClientIT {
+class RestClientTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/pom.xml
+++ b/integration-test/tck/pom.xml
@@ -11,4 +11,19 @@
     <artifactId>quarkus-http-problem-integration-test-tck</artifactId>
     <name>Quarkus - HTTP-Problem - Integration Tests - RFC 9457 TCK</name>
 
+    <build>
+        <plugins>
+            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457AboutBlankNativeIT extends Rfc9457AboutBlankIT {
+class Rfc9457AboutBlankNativeIT extends Rfc9457AboutBlankTest {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class Rfc9457AboutBlankIT {
+class Rfc9457AboutBlankTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457CompleteProblemNativeIT extends Rfc9457CompleteProblemIT {
+class Rfc9457CompleteProblemNativeIT extends Rfc9457CompleteProblemTest {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class Rfc9457CompleteProblemIT {
+class Rfc9457CompleteProblemTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457ExtensionMembersNativeIT extends Rfc9457ExtensionMembersIT {
+class Rfc9457ExtensionMembersNativeIT extends Rfc9457ExtensionMembersTest {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class Rfc9457ExtensionMembersIT {
+class Rfc9457ExtensionMembersTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457StandardMembersNativeIT extends Rfc9457StandardMembersIT {
+class Rfc9457StandardMembersNativeIT extends Rfc9457StandardMembersTest {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class Rfc9457StandardMembersIT {
+class Rfc9457StandardMembersTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/zalando/pom.xml
+++ b/integration-test/zalando/pom.xml
@@ -17,4 +17,20 @@
             <artifactId>problem</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperNativeIT.java
+++ b/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class ZalandoProblemMapperNativeIT extends ZalandoProblemMapperIT {
+class ZalandoProblemMapperNativeIT extends ZalandoProblemMapperTest {
 }

--- a/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
+++ b/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
@@ -9,7 +9,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class ZalandoProblemMapperIT {
+class ZalandoProblemMapperTest {
 
     static final String SAMPLE_TITLE = "I'm a teapot";
     static final String SAMPLE_DETAIL = "A small one";


### PR DESCRIPTION
Always include the core IT module in the Maven reactor (not only under -Pit) and attach a test-jar so releases publish both the main artifact and *-tests.jar. Optional IT modules (openapi, zalando, rest-client) stay behind the it profile for this repo's CI matrix.

Required so Quarkus Platform can re-run the suite for BOM compatibility: https://github.com/quarkusio/quarkus-platform/pull/1982 https://github.com/quarkusio/quarkus-platform/pull/1982#issuecomment-4874584007. Platform tests will exercise the reactive REST + Jackson path only — not the full CI matrix (jsonb, classic rest providers). That is usually fine as the representative suite.

The main reason it was **not** published before is [official quarkiverse faq](https://github.com/quarkiverse/quarkiverse/wiki/Release#release-fails-while-deploying-the-integration-tests-and-docs) entry, which is not really applicable to Platform extensions.