### PR TITLE
Add RFC 9457 TCK integration test module

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -93,6 +93,7 @@
                 <module>openapi</module>
                 <module>zalando</module>
                 <module>rest-client</module>
+                <module>tck</module>
             </modules>
         </profile>
         <profile>

--- a/integration-test/tck/pom.xml
+++ b/integration-test/tck/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.httpproblem</groupId>
+        <artifactId>quarkus-http-problem-integration-test</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-http-problem-integration-test-tck</artifactId>
+    <name>Quarkus - HTTP-Problem - Integration Tests - RFC 9457 TCK</name>
+
+</project>

--- a/integration-test/tck/src/main/java/io/quarkiverse/httpproblem/Rfc9457Resource.java
+++ b/integration-test/tck/src/main/java/io/quarkiverse/httpproblem/Rfc9457Resource.java
@@ -1,0 +1,195 @@
+package io.quarkiverse.httpproblem;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/throw/rfc9457/")
+@Produces(MediaType.APPLICATION_JSON)
+public class Rfc9457Resource {
+
+    @GET
+    @Path("/complete")
+    public void throwComplete() {
+        throw HttpProblem.builder()
+                .withType(URI.create("https://example.com/probs/out-of-credit"))
+                .withTitle("You do not have enough credit.")
+                .withStatus(Response.Status.FORBIDDEN)
+                .withDetail("Your current balance is 30, but that costs 50.")
+                .withInstance(URI.create("https://example.net/account/12345/msgs/abc"))
+                .with("balance", 30)
+                .with("accounts", List.of("/account/12345", "/account/67890"))
+                .build();
+    }
+
+    @GET
+    @Path("/minimal")
+    public void throwMinimal() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.INTERNAL_SERVER_ERROR)
+                .build();
+    }
+
+    @GET
+    @Path("/with-type")
+    public void throwWithType() {
+        throw HttpProblem.builder()
+                .withType(URI.create("https://example.com/probs/invalid-parameter"))
+                .withTitle("Invalid Parameter")
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withDetail("The 'age' parameter must be a positive integer.")
+                .build();
+    }
+
+    @GET
+    @Path("/without-type")
+    public void throwWithoutType() {
+        throw HttpProblem.builder()
+                .withTitle("Not Found")
+                .withStatus(Response.Status.NOT_FOUND)
+                .withDetail("The requested resource was not found.")
+                .build();
+    }
+
+    @GET
+    @Path("/with-status")
+    public void throwWithStatus(@QueryParam("status") int status) {
+        Response.Status responseStatus = Response.Status.fromStatusCode(status);
+        String title = responseStatus != null ? responseStatus.getReasonPhrase() : "Unknown";
+        throw HttpProblem.builder()
+                .withStatus(status)
+                .withTitle(title)
+                .build();
+    }
+
+    @GET
+    @Path("/with-detail")
+    public void throwWithDetail() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withTitle("Validation Error")
+                .withDetail("Field 'email' is not a valid email address.")
+                .build();
+    }
+
+    @GET
+    @Path("/with-instance")
+    public void throwWithInstance() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.NOT_FOUND)
+                .withTitle("Not Found")
+                .withInstance(URI.create("https://example.com/errors/404/abc123"))
+                .build();
+    }
+
+    @GET
+    @Path("/without-instance")
+    public void throwWithoutInstance() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.NOT_FOUND)
+                .withTitle("Not Found")
+                .build();
+    }
+
+    @GET
+    @Path("/with-type-urn")
+    public void throwWithTypeUrn() {
+        throw HttpProblem.builder()
+                .withType(URI.create("urn:example:problem:validation-error"))
+                .withTitle("Validation Error")
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withDetail("Non-HTTP URI scheme for type member.")
+                .build();
+    }
+
+    @GET
+    @Path("/with-extensions")
+    public void throwWithExtensions() {
+        throw HttpProblem.builder()
+                .withType(URI.create("https://example.com/probs/validation-error"))
+                .withTitle("Validation Error")
+                .withStatus(Response.Status.BAD_REQUEST)
+                .with("invalid_params", List.of("name", "age"))
+                .with("retry_after", 30)
+                .with("documentation_url", "https://api.example.com/docs/errors/validation")
+                .build();
+    }
+
+    @GET
+    @Path("/with-single-extension")
+    public void throwWithSingleExtension() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.CONFLICT)
+                .withTitle("Conflict")
+                .withDetail("Resource version conflict.")
+                .with("current_version", 42)
+                .build();
+    }
+
+    @GET
+    @Path("/with-nested-extension")
+    public void throwWithNestedExtension() {
+        Map<String, Object> address = new LinkedHashMap<>();
+        address.put("street", "123 Main St");
+        address.put("city", "Springfield");
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withTitle("Validation Error")
+                .with("nested_object", address)
+                .with("is_retryable", true)
+                .build();
+    }
+
+    @GET
+    @Path("/about-blank")
+    public void throwAboutBlank(@QueryParam("status") int status) {
+        Response.Status responseStatus = Response.Status.fromStatusCode(status);
+        if (responseStatus == null) {
+            throw HttpProblem.builder()
+                    .withStatus(status)
+                    .build();
+        }
+        throw HttpProblem.valueOf(responseStatus);
+    }
+
+    @GET
+    @Path("/about-blank-explicit")
+    public void throwAboutBlankExplicit() {
+        throw HttpProblem.builder()
+                .withType(URI.create("about:blank"))
+                .withTitle("Not Found")
+                .withStatus(Response.Status.NOT_FOUND)
+                .build();
+    }
+
+    @GET
+    @Path("/about-blank-with-detail")
+    public void throwAboutBlankWithDetail() {
+        throw HttpProblem.builder()
+                .withType(URI.create("about:blank"))
+                .withTitle("Bad Request")
+                .withStatus(Response.Status.BAD_REQUEST)
+                .withDetail("The 'name' query parameter is required.")
+                .build();
+    }
+
+    @GET
+    @Path("/with-headers")
+    public void throwWithHeaders() {
+        throw HttpProblem.builder()
+                .withStatus(Response.Status.TOO_MANY_REQUESTS)
+                .withTitle("Too Many Requests")
+                .withDetail("Rate limit exceeded.")
+                .withHeader("Retry-After", "60")
+                .withHeader("X-RateLimit-Remaining", "0")
+                .build();
+    }
+}

--- a/integration-test/tck/src/main/resources/application.properties
+++ b/integration-test/tck/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.default-locale=en-US

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankIT.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@QuarkusTest
+class Rfc9457AboutBlankIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @ParameterizedTest(name = "RFC 9457 Section 4.2.1 - about:blank title for status {0} should match HTTP reason phrase")
+    @ValueSource(ints = { 400, 401, 403, 404, 405, 409, 500, 502, 503 })
+    void aboutBlankTitleShouldMatchStatusPhrase(int status) {
+        String expectedTitle = Response.Status.fromStatusCode(status).getReasonPhrase();
+
+        given()
+                .queryParam("status", status)
+                .get("/throw/rfc9457/about-blank")
+                .then()
+                .statusCode(status)
+                .body("status", equalTo(status))
+                .body("title", equalTo(expectedTitle));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 4.2.1 - explicit about:blank type should appear in JSON")
+    void aboutBlankExplicitTypeShouldBeInResponse() {
+        when()
+                .get("/throw/rfc9457/about-blank-explicit")
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode())
+                .body("type", equalTo("about:blank"))
+                .body("title", equalTo(NOT_FOUND.getReasonPhrase()));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 4.2.1 - implicit about:blank (valueOf) should omit type from JSON")
+    void implicitAboutBlankShouldOmitType() {
+        given()
+                .queryParam("status", NOT_FOUND.getStatusCode())
+                .get("/throw/rfc9457/about-blank")
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode())
+                .body("type", nullValue())
+                .body("title", equalTo(NOT_FOUND.getReasonPhrase()));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 4.2.1 - about:blank with non-standard status code should fall back to builder")
+    void aboutBlankWithNonStandardStatusShouldFallBackToBuilder() {
+        given()
+                .queryParam("status", 418)
+                .get("/throw/rfc9457/about-blank")
+                .then()
+                .statusCode(418)
+                .body("status", equalTo(418));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 4.2.1 - about:blank problem can include detail")
+    void aboutBlankWithDetailShouldIncludeDetail() {
+        when()
+                .get("/throw/rfc9457/about-blank-with-detail")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("type", equalTo("about:blank"))
+                .body("detail", equalTo("The 'name' query parameter is required."));
+    }
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.httpproblem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Rfc9457AboutBlankNativeIT extends Rfc9457AboutBlankIT {
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemIT.java
@@ -1,0 +1,131 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class Rfc9457CompleteProblemIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3 - Content-Type should be application/problem+json for complete problem")
+    void contentTypeShouldBeApplicationProblemJsonForCompleteProblem() {
+        String contentType = when()
+                .get("/throw/rfc9457/complete")
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .extract().contentType();
+
+        assertThat(contentType).contains("application/problem+json");
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3 - Content-Type should be application/problem+json for minimal problem")
+    void contentTypeShouldBeApplicationProblemJsonForMinimalProblem() {
+        String contentType = when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .extract().contentType();
+
+        assertThat(contentType).contains("application/problem+json");
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3 - Content-Type should be application/problem+json for about:blank problem")
+    void contentTypeShouldBeApplicationProblemJsonForAboutBlank() {
+        String contentType = given()
+                .queryParam("status", NOT_FOUND.getStatusCode())
+                .get("/throw/rfc9457/about-blank")
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode())
+                .extract().contentType();
+
+        assertThat(contentType).contains("application/problem+json");
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3 - complete problem should contain all standard and extension members")
+    void completeProblemShouldContainAllMembers() {
+        when()
+                .get("/throw/rfc9457/complete")
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .body("type", equalTo("https://example.com/probs/out-of-credit"))
+                .body("title", equalTo("You do not have enough credit."))
+                .body("status", equalTo(FORBIDDEN.getStatusCode()))
+                .body("detail", equalTo("Your current balance is 30, but that costs 50."))
+                .body("instance", equalTo("https://example.net/account/12345/msgs/abc"))
+                .body("balance", equalTo(30))
+                .body("accounts", hasItems("/account/12345", "/account/67890"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 - minimal problem should contain only status and auto-set instance")
+    void minimalProblemShouldContainOnlyStatusAndInstance() {
+        when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .body("status", equalTo(INTERNAL_SERVER_ERROR.getStatusCode()))
+                .body("type", nullValue())
+                .body("title", nullValue())
+                .body("detail", nullValue())
+                .body("instance", equalTo("/throw/rfc9457/minimal"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 - null optional fields should not appear in JSON (not serialized as null)")
+    void nullFieldsShouldNotBeSerialized() {
+        String body = when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .extract().body().asString();
+
+        assertThat(body).doesNotContain("\"type\"");
+        assertThat(body).doesNotContain("\"title\"");
+        assertThat(body).doesNotContain("\"detail\"");
+        assertThat(body).contains("\"status\"");
+        assertThat(body).contains("\"instance\"");
+    }
+
+    @Test
+    @DisplayName("RFC 9457 - stacktrace should never be exposed in problem response")
+    void stacktraceShouldNeverAppear() {
+        when()
+                .get("/throw/rfc9457/complete")
+                .then()
+                .body("stacktrace", nullValue());
+
+        when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .body("stacktrace", nullValue());
+
+        when()
+                .get("/throw/rfc9457/with-extensions")
+                .then()
+                .body("stacktrace", nullValue());
+
+        given()
+                .queryParam("status", 500)
+                .get("/throw/rfc9457/about-blank")
+                .then()
+                .body("stacktrace", nullValue());
+    }
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.httpproblem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Rfc9457CompleteProblemNativeIT extends Rfc9457CompleteProblemIT {
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersIT.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.when;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
+import static jakarta.ws.rs.core.Response.Status.TOO_MANY_REQUESTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class Rfc9457ExtensionMembersIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.2 - extension members should appear in response body")
+    void extensionMembersShouldAppearInBody() {
+        when()
+                .get("/throw/rfc9457/with-extensions")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("invalid_params", hasItems("name", "age"))
+                .body("retry_after", equalTo(30))
+                .body("documentation_url", equalTo("https://api.example.com/docs/errors/validation"));
+    }
+
+    @Test
+    @DisplayName("Implementation quality - extension members should appear after standard members in JSON")
+    void extensionMembersShouldAppearAfterStandardMembers() {
+        String body = when()
+                .get("/throw/rfc9457/with-extensions")
+                .then()
+                .extract().body().asString();
+
+        assertThat(body.indexOf("\"status\"")).isLessThan(body.indexOf("\"invalid_params\""));
+        assertThat(body.indexOf("\"title\"")).isLessThan(body.indexOf("\"retry_after\""));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.2 - single extension member should appear in body")
+    void singleExtensionMemberShouldAppearInBody() {
+        when()
+                .get("/throw/rfc9457/with-single-extension")
+                .then()
+                .statusCode(CONFLICT.getStatusCode())
+                .body("current_version", equalTo(42));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.2 - extension members with nested objects and booleans")
+    void nestedObjectAndBooleanExtensionMembers() {
+        when()
+                .get("/throw/rfc9457/with-nested-extension")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("nested_object.street", equalTo("123 Main St"))
+                .body("nested_object.city", equalTo("Springfield"))
+                .body("is_retryable", equalTo(true));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.2 - extension members should coexist with all standard members")
+    void extensionMembersCoexistWithStandardMembers() {
+        when()
+                .get("/throw/rfc9457/with-extensions")
+                .then()
+                .body("type", equalTo("https://example.com/probs/validation-error"))
+                .body("status", equalTo(BAD_REQUEST.getStatusCode()))
+                .body("title", equalTo("Validation Error"))
+                .body("invalid_params", hasItems("name", "age"))
+                .body("retry_after", equalTo(30));
+    }
+
+    @Test
+    @DisplayName("Headers should be HTTP response headers, not serialized in JSON body")
+    void headersShouldNotAppearInResponseBody() {
+        when()
+                .get("/throw/rfc9457/with-headers")
+                .then()
+                .statusCode(TOO_MANY_REQUESTS.getStatusCode())
+                .header("Retry-After", equalTo("60"))
+                .header("X-RateLimit-Remaining", equalTo("0"))
+                .body("Retry-After", nullValue())
+                .body("X-RateLimit-Remaining", nullValue());
+    }
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.httpproblem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Rfc9457ExtensionMembersNativeIT extends Rfc9457ExtensionMembersIT {
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersIT.java
@@ -1,0 +1,157 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@QuarkusTest
+class Rfc9457StandardMembersIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.1 - type should be an absolute URI when explicitly set")
+    void typeShouldBeAbsoluteUri() {
+        when()
+                .get("/throw/rfc9457/with-type")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("type", equalTo("https://example.com/probs/invalid-parameter"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.1 - type should be absent from JSON when not set")
+    void typeShouldBeAbsentWhenNotSet() {
+        String body = when()
+                .get("/throw/rfc9457/without-type")
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode())
+                .body("type", nullValue())
+                .extract().body().asString();
+
+        assertThat(body).doesNotContain("\"type\"");
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.1 - type should accept non-HTTP URI schemes such as URNs")
+    void typeShouldAcceptUrnScheme() {
+        when()
+                .get("/throw/rfc9457/with-type-urn")
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("type", equalTo("urn:example:problem:validation-error"));
+    }
+
+    @ParameterizedTest(name = "RFC 9457 Section 3.1.2 - status {0} in body should match HTTP status")
+    @ValueSource(ints = { 400, 403, 404, 500, 502 })
+    void statusInBodyShouldMatchHttpStatus(int status) {
+        given()
+                .queryParam("status", status)
+                .get("/throw/rfc9457/with-status")
+                .then()
+                .statusCode(status)
+                .body("status", equalTo(status));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.2 - status should always be present even in minimal problem")
+    void statusShouldAlwaysBePresent() {
+        when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .body("status", equalTo(INTERNAL_SERVER_ERROR.getStatusCode()));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.2 - status should be a JSON number")
+    void statusShouldBeNumeric() {
+        Object status = given()
+                .queryParam("status", BAD_REQUEST.getStatusCode())
+                .get("/throw/rfc9457/with-status")
+                .then()
+                .extract().body().jsonPath().get("status");
+
+        assertThat(status).isInstanceOf(Integer.class);
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.3 - title should be present when set")
+    void titleShouldBePresent() {
+        when()
+                .get("/throw/rfc9457/with-type")
+                .then()
+                .body("title", equalTo("Invalid Parameter"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.3 - title should be absent when not set")
+    void titleShouldBeAbsentWhenNotSet() {
+        when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .body("title", nullValue());
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.4 - detail should be present when set")
+    void detailShouldBePresent() {
+        when()
+                .get("/throw/rfc9457/with-detail")
+                .then()
+                .body("detail", equalTo("Field 'email' is not a valid email address."));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.4 - detail should be absent when not set")
+    void detailShouldBeAbsentWhenNotSet() {
+        when()
+                .get("/throw/rfc9457/minimal")
+                .then()
+                .body("detail", nullValue());
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.5 - instance should be the explicit URI when set")
+    void instanceShouldBeExplicitUriWhenSet() {
+        when()
+                .get("/throw/rfc9457/with-instance")
+                .then()
+                .body("instance", equalTo("https://example.com/errors/404/abc123"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.2 - non-standard status code should still be returned correctly")
+    void nonStandardStatusCodeShouldBeReturned() {
+        given()
+                .queryParam("status", 418)
+                .get("/throw/rfc9457/with-status")
+                .then()
+                .statusCode(418)
+                .body("status", equalTo(418))
+                .body("title", equalTo("Unknown"));
+    }
+
+    @Test
+    @DisplayName("RFC 9457 Section 3.1.5 - instance defaults to request path via ProblemDefaultsProvider")
+    void instanceShouldDefaultToRequestPath() {
+        when()
+                .get("/throw/rfc9457/without-instance")
+                .then()
+                .body("instance", equalTo("/throw/rfc9457/without-instance"));
+    }
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.httpproblem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Rfc9457StandardMembersNativeIT extends Rfc9457StandardMembersIT {
+}


### PR DESCRIPTION
Adds a dedicated integration test module that validates RFC 9457 (Problem Details for HTTP APIs) compliance across the standard members (type, status, title, detail, instance), extension members, about:blank semantics, content-type negotiation, and complete problem structure.

Tests are organized into four classes by RFC section, each with a corresponding NativeIT variant. Coverage includes non-standard HTTP status codes (e.g. 418) to verify both the builder and valueOf code paths handle unrecognized statuses correctly, and assertions that stacktraces are never leaked in responses.