### PR TITLE
Add Jackson exception mappers for MismatchedInputException and InvalidDefinitionException

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.openapi.OASFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
@@ -88,6 +89,12 @@ public class ProblemProcessor {
                         .onlyIf(new JacksonDetector()),
                 mapper(EXTENSION_MAIN_PACKAGE + "jackson.InvalidFormatExceptionMapper")
                         .thatHandles("com.fasterxml.jackson.databind.exc.InvalidFormatException")
+                        .onlyIf(new JacksonDetector()),
+                mapper(EXTENSION_MAIN_PACKAGE + "jackson.MismatchedInputExceptionMapper")
+                        .thatHandles("com.fasterxml.jackson.databind.exc.MismatchedInputException")
+                        .onlyIf(new JacksonDetector()),
+                mapper(EXTENSION_MAIN_PACKAGE + "jackson.InvalidDefinitionExceptionMapper")
+                        .thatHandles("com.fasterxml.jackson.databind.exc.InvalidDefinitionException")
                         .onlyIf(new JacksonDetector()),
 
                 mapper(EXTENSION_MAIN_PACKAGE + "jsonb.RestEasyClassicJsonbExceptionMapper")
@@ -223,6 +230,7 @@ public class ProblemProcessor {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemLogger.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemDefaultsProvider.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(MdcPropertiesInjector.class));
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(DetailSanitizer.class));
     }
 
     @BuildStep

--- a/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
@@ -64,6 +64,8 @@ class ProblemProcessorTest {
             "AuthenticationFailedException, authentication-failed-exception",
             "ConstraintViolationException, constraint-violation-exception",
             "JsonProcessingException, json-processing-exception",
+            "MismatchedInputException, mismatched-input-exception",
+            "InvalidDefinitionException, invalid-definition-exception",
             "Exception, exception"
     })
     void toKebabCaseShouldConvertClassNamesCorrectly(String input, String expected) {

--- a/integration-test/core/pom.xml
+++ b/integration-test/core/pom.xml
@@ -22,20 +22,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ConstraintViolationMapperConfigIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ConstraintViolationMapperConfigIT.java
@@ -14,8 +14,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
-@TestProfile(ConstraintViolationMapperConfigTest.CustomHttpStatus.class)
-class ConstraintViolationMapperConfigTest {
+@TestProfile(ConstraintViolationMapperConfigIT.CustomHttpStatus.class)
+class ConstraintViolationMapperConfigIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/DisabledMapperIT.java
@@ -12,8 +12,8 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(DisabledMapperTest.WebApplicationExceptionMapperDisabled.class)
-class DisabledMapperTest {
+@TestProfile(DisabledMapperIT.WebApplicationExceptionMapperDisabled.class)
+class DisabledMapperIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersIT.java
@@ -11,7 +11,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class GenericMappersTest {
+class GenericMappersIT {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/GenericMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class GenericMappersNativeIT extends GenericMappersTest {
+class GenericMappersNativeIT extends GenericMappersIT {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersIT.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class JaxRsMappersTest {
+class JaxRsMappersIT {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JaxRsMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class JaxRsMappersNativeIT extends JaxRsMappersTest {
+class JaxRsMappersNativeIT extends JaxRsMappersIT {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersIT.java
@@ -22,11 +22,11 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-class JsonMappersTest {
+class JsonMappersIT {
 
     static final String SANITIZED_DETAIL = "Malformed request body";
 
-    private static final Logger logger = LoggerFactory.getLogger(JsonMappersTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(JsonMappersIT.class);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/JsonMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class JsonMappersNativeIT extends JsonMappersTest {
+class JsonMappersNativeIT extends JsonMappersIT {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcIT.java
@@ -8,7 +8,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class MdcTest {
+class MdcIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/MdcNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class MdcNativeIT extends MdcTest {
+class MdcNativeIT extends MdcIT {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersIT.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import jakarta.ws.rs.core.HttpHeaders;
 
 @QuarkusTest
-class SecurityMappersTest {
+class SecurityMappersIT {
 
     static final String SAMPLE_DETAIL = "A small one";
 

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/SecurityMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class SecurityMappersNativeIT extends SecurityMappersTest {
+class SecurityMappersNativeIT extends SecurityMappersIT {
 }

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/UnsanitizedJsonMappersIT.java
@@ -26,12 +26,12 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
-@TestProfile(UnsanitizedJsonMappersTest.SanitizationDisabled.class)
-class UnsanitizedJsonMappersTest {
+@TestProfile(UnsanitizedJsonMappersIT.SanitizationDisabled.class)
+class UnsanitizedJsonMappersIT {
 
     static final String SANITIZED_DETAIL = "Malformed request body";
 
-    private static final Logger logger = LoggerFactory.getLogger(UnsanitizedJsonMappersTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(UnsanitizedJsonMappersIT.class);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersIT.java
@@ -13,7 +13,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class ValidationMappersTest {
+class ValidationMappersIT {
 
     static final String SAMPLE_DETAIL = "A small one";
     final String TOO_SHORT_NAME = "N";

--- a/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersNativeIT.java
+++ b/integration-test/core/src/test/java/io/quarkiverse/httpproblem/ValidationMappersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class ValidationMappersNativeIT extends ValidationMappersTest {
+class ValidationMappersNativeIT extends ValidationMappersIT {
 }

--- a/integration-test/openapi/pom.xml
+++ b/integration-test/openapi/pom.xml
@@ -22,19 +22,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiIT.java
+++ b/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiIT.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
  * but brackets work fine
  */
 @QuarkusTest
-class OpenApiTest {
+class OpenApiIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiNativeIT.java
+++ b/integration-test/openapi/src/test/java/io/quarkiverse/httpproblem/OpenApiNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class OpenApiNativeIT extends OpenApiTest {
+class OpenApiNativeIT extends OpenApiIT {
 }

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -12,20 +12,6 @@
     <name>Quarkus - HTTP-Problem - Integration Tests</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <!-- we only run the tests when the it profile is enabled -->
-        <skipSurefireTests>true</skipSurefireTests>
-    </properties>
-
-    <!-- we always publish the modules for consumption by the Quarkus Platform -->
-    <modules>
-        <module>core</module>
-        <module>openapi</module>
-        <module>rest-client</module>
-        <module>zalando</module>
-        <module>tck</module>
-    </modules>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.httpproblem</groupId>
@@ -66,10 +52,20 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <skip>${skipSurefireTests}</skip>
+                    <excludes>
+                        <exclude>**/*NativeIT.java</exclude>
+                    </excludes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
@@ -78,6 +74,7 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
@@ -91,10 +88,13 @@
     <profiles>
         <profile>
             <id>it</id>
-            <properties>
-                <!-- we only run the tests when the it profile is enabled -->
-                <skipSurefireTests>false</skipSurefireTests>
-            </properties>
+            <modules>
+                <module>core</module>
+                <module>openapi</module>
+                <module>zalando</module>
+                <module>rest-client</module>
+                <module>tck</module>
+            </modules>
         </profile>
         <profile>
             <id>jackson</id>
@@ -140,7 +140,6 @@
             <id>native</id>
             <properties>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
-                <skipSurefireTests>true</skipSurefireTests>
             </properties>
 
             <build>

--- a/integration-test/rest-client/pom.xml
+++ b/integration-test/rest-client/pom.xml
@@ -55,20 +55,4 @@
             </dependencies>
         </profile>
     </profiles>
-
-    <build>
-        <plugins>
-            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientIT.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
-class RestClientTest {
+class RestClientIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientNativeIT.java
+++ b/integration-test/rest-client/src/test/java/io/quarkiverse/httpproblem/client/RestClientNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem.client;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class RestClientNativeIT extends RestClientTest {
+class RestClientNativeIT extends RestClientIT {
 }

--- a/integration-test/tck/pom.xml
+++ b/integration-test/tck/pom.xml
@@ -11,19 +11,4 @@
     <artifactId>quarkus-http-problem-integration-test-tck</artifactId>
     <name>Quarkus - HTTP-Problem - Integration Tests - RFC 9457 TCK</name>
 
-    <build>
-        <plugins>
-            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankIT.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class Rfc9457AboutBlankTest {
+class Rfc9457AboutBlankIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457AboutBlankNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457AboutBlankNativeIT extends Rfc9457AboutBlankTest {
+class Rfc9457AboutBlankNativeIT extends Rfc9457AboutBlankIT {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemIT.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class Rfc9457CompleteProblemTest {
+class Rfc9457CompleteProblemIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457CompleteProblemNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457CompleteProblemNativeIT extends Rfc9457CompleteProblemTest {
+class Rfc9457CompleteProblemNativeIT extends Rfc9457CompleteProblemIT {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersIT.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class Rfc9457ExtensionMembersTest {
+class Rfc9457ExtensionMembersIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457ExtensionMembersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457ExtensionMembersNativeIT extends Rfc9457ExtensionMembersTest {
+class Rfc9457ExtensionMembersNativeIT extends Rfc9457ExtensionMembersIT {
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersIT.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
-class Rfc9457StandardMembersTest {
+class Rfc9457StandardMembersIT {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class Rfc9457StandardMembersNativeIT extends Rfc9457StandardMembersTest {
+class Rfc9457StandardMembersNativeIT extends Rfc9457StandardMembersIT {
 }

--- a/integration-test/zalando/pom.xml
+++ b/integration-test/zalando/pom.xml
@@ -17,20 +17,4 @@
             <artifactId>problem</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!-- Required so Quarkus Platform can re-run these ITs from the published *-tests.jar -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperIT.java
+++ b/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperIT.java
@@ -9,7 +9,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class ZalandoProblemMapperTest {
+class ZalandoProblemMapperIT {
 
     static final String SAMPLE_TITLE = "I'm a teapot";
     static final String SAMPLE_DETAIL = "A small one";

--- a/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperNativeIT.java
+++ b/integration-test/zalando/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperNativeIT.java
@@ -3,5 +3,5 @@ package io.quarkiverse.httpproblem;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class ZalandoProblemMapperNativeIT extends ZalandoProblemMapperTest {
+class ZalandoProblemMapperNativeIT extends ZalandoProblemMapperIT {
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/DetailSanitizer.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/DetailSanitizer.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.httpproblem;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DetailSanitizer {
+
+    public static final String SANITIZED_DETAIL = "Malformed request body";
+
+    private final boolean includeDetails;
+
+    public DetailSanitizer() {
+        this(false);
+    }
+
+    @Inject
+    public DetailSanitizer(ProblemRuntimeFixedConfig config) {
+        this(config.includeDetails());
+    }
+
+    public DetailSanitizer(boolean includeDetails) {
+        this.includeDetails = includeDetails;
+    }
+
+    public String sanitize(String rawDetail) {
+        return includeDetails ? rawDetail : SANITIZED_DETAIL;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapper.java
@@ -5,7 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
@@ -13,26 +13,27 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
- * Mapper for Jackson InvalidFormatException, which is more specialised version of JsonProcessingException
+ * Mapper for Jackson InvalidDefinitionException, which is more specialized version of JsonProcessingException,
+ * This exception has a specific mapper in Quarkus REST.
  */
 @Priority(Priorities.USER - 1)
-public final class InvalidFormatExceptionMapper extends ExceptionMapperBase<InvalidFormatException> {
+public final class InvalidDefinitionExceptionMapper extends ExceptionMapperBase<InvalidDefinitionException> {
 
     private final DetailSanitizer detailSanitizer;
 
-    public InvalidFormatExceptionMapper() {
+    public InvalidDefinitionExceptionMapper() {
         this.detailSanitizer = new DetailSanitizer();
     }
 
     @Inject
-    public InvalidFormatExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+    public InvalidDefinitionExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
             DetailSanitizer detailSanitizer) {
         super(postProcessorsRegistry);
         this.detailSanitizer = detailSanitizer;
     }
 
     @Override
-    protected HttpProblem toProblem(InvalidFormatException exception) {
+    protected HttpProblem toProblem(InvalidDefinitionException exception) {
         return HttpProblem.builder()
                 .withStatus(Response.Status.BAD_REQUEST)
                 .withTitle(Response.Status.BAD_REQUEST.getReasonPhrase())

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JacksonFieldPathSerializer.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JacksonFieldPathSerializer.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.httpproblem.jackson;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+final class JacksonFieldPathSerializer {
+
+    private JacksonFieldPathSerializer() {
+    }
+
+    static String serializePath(List<JsonMappingException.Reference> path) {
+        String pathString = path.stream()
+                .map(JacksonFieldPathSerializer::refToString)
+                .collect(Collectors.joining());
+        return removeFirstDot(pathString);
+    }
+
+    private static String refToString(JsonMappingException.Reference ref) {
+        if (ref.getFieldName() != null) {
+            return "." + ref.getFieldName();
+        }
+        if (ref.getIndex() >= 0) {
+            return "[" + ref.getIndex() + "]";
+        }
+        return ".?";
+    }
+
+    private static String removeFirstDot(String field) {
+        if (field.isEmpty()) {
+            return "?";
+        }
+        if (field.charAt(0) == '.') {
+            return field.substring(1);
+        }
+        return field;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapper.java
@@ -8,9 +8,9 @@ import jakarta.ws.rs.Priorities;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 /**
@@ -19,25 +19,21 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 @Priority(Priorities.USER)
 public final class JsonProcessingExceptionMapper extends ExceptionMapperBase<JsonProcessingException> {
 
-    static final String SANITIZED_DETAIL = "Malformed request body";
-
-    private boolean includeDetails;
+    private final DetailSanitizer detailSanitizer;
 
     public JsonProcessingExceptionMapper() {
-        this.includeDetails = false;
+        this.detailSanitizer = new DetailSanitizer();
     }
 
     @Inject
-    public JsonProcessingExceptionMapper(PostProcessorsRegistry postProcessorsRegistry, ProblemRuntimeFixedConfig config) {
+    public JsonProcessingExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            DetailSanitizer detailSanitizer) {
         super(postProcessorsRegistry);
-        this.includeDetails = config.includeDetails();
+        this.detailSanitizer = detailSanitizer;
     }
 
     @Override
     protected HttpProblem toProblem(JsonProcessingException exception) {
-        String detail = includeDetails
-                ? exception.getOriginalMessage()
-                : SANITIZED_DETAIL;
-        return HttpProblem.valueOf(BAD_REQUEST, detail);
+        return HttpProblem.valueOf(BAD_REQUEST, detailSanitizer.sanitize(exception.getOriginalMessage()));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapper.java
@@ -5,34 +5,31 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
-/**
- * Mapper for Jackson InvalidFormatException, which is more specialised version of JsonProcessingException
- */
 @Priority(Priorities.USER - 1)
-public final class InvalidFormatExceptionMapper extends ExceptionMapperBase<InvalidFormatException> {
+public final class MismatchedInputExceptionMapper extends ExceptionMapperBase<MismatchedInputException> {
 
     private final DetailSanitizer detailSanitizer;
 
-    public InvalidFormatExceptionMapper() {
+    public MismatchedInputExceptionMapper() {
         this.detailSanitizer = new DetailSanitizer();
     }
 
     @Inject
-    public InvalidFormatExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+    public MismatchedInputExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
             DetailSanitizer detailSanitizer) {
         super(postProcessorsRegistry);
         this.detailSanitizer = detailSanitizer;
     }
 
     @Override
-    protected HttpProblem toProblem(InvalidFormatException exception) {
+    protected HttpProblem toProblem(MismatchedInputException exception) {
         return HttpProblem.builder()
                 .withStatus(Response.Status.BAD_REQUEST)
                 .withTitle(Response.Status.BAD_REQUEST.getReasonPhrase())

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapper.java
@@ -7,33 +7,30 @@ import jakarta.inject.Inject;
 import jakarta.json.bind.JsonbException;
 import jakarta.ws.rs.Priorities;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 public final class JsonbExceptionMapper extends ExceptionMapperBase<JsonbException> {
 
-    static final String SANITIZED_DETAIL = "Malformed request body";
-
-    private boolean includeDetails;
+    private final DetailSanitizer detailSanitizer;
 
     public JsonbExceptionMapper() {
-        this.includeDetails = false;
+        this.detailSanitizer = new DetailSanitizer();
     }
 
     @Inject
-    public JsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry, ProblemRuntimeFixedConfig config) {
+    public JsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
+            DetailSanitizer detailSanitizer) {
         super(postProcessorsRegistry);
-        this.includeDetails = config.includeDetails();
+        this.detailSanitizer = detailSanitizer;
     }
 
     @Override
     protected HttpProblem toProblem(JsonbException exception) {
-        if (!includeDetails) {
-            return HttpProblem.valueOf(BAD_REQUEST, SANITIZED_DETAIL);
-        }
-        return HttpProblem.valueOf(BAD_REQUEST, exception.getCause() == null ? null : exception.getCause().getMessage());
+        String rawDetail = exception.getCause() == null ? null : exception.getCause().getMessage();
+        return HttpProblem.valueOf(BAD_REQUEST, detailSanitizer.sanitize(rawDetail));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapper.java
@@ -8,27 +8,25 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ProcessingException;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ExceptionMapperBase;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 
 @Priority(Priorities.USER)
 public final class RestEasyClassicJsonbExceptionMapper extends ExceptionMapperBase<ProcessingException> {
 
-    static final String SANITIZED_DETAIL = "Malformed request body";
-
-    private boolean includeDetails;
+    private final DetailSanitizer detailSanitizer;
 
     public RestEasyClassicJsonbExceptionMapper() {
-        this.includeDetails = false;
+        this.detailSanitizer = new DetailSanitizer();
     }
 
     @Inject
     public RestEasyClassicJsonbExceptionMapper(PostProcessorsRegistry postProcessorsRegistry,
-            ProblemRuntimeFixedConfig config) {
+            DetailSanitizer detailSanitizer) {
         super(postProcessorsRegistry);
-        this.includeDetails = config.includeDetails();
+        this.detailSanitizer = detailSanitizer;
     }
 
     /**
@@ -41,10 +39,7 @@ public final class RestEasyClassicJsonbExceptionMapper extends ExceptionMapperBa
     protected HttpProblem toProblem(ProcessingException exception) {
         if (exception.getCause() != null
                 && exception.getCause().getClass().getName().equals("jakarta.json.bind.JsonbException")) {
-            String detail = includeDetails
-                    ? exception.getCause().getMessage()
-                    : SANITIZED_DETAIL;
-            return HttpProblem.valueOf(BAD_REQUEST, detail);
+            return HttpProblem.valueOf(BAD_REQUEST, detailSanitizer.sanitize(exception.getCause().getMessage()));
         } else {
             return HttpProblem.valueOf(INTERNAL_SERVER_ERROR);
         }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.HttpProblem;
@@ -19,15 +19,15 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
-class InvalidFormatExceptionMapperTest {
+class InvalidDefinitionExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
             List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
-    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry, new DetailSanitizer(true));
+    InvalidDefinitionExceptionMapper mapper = new InvalidDefinitionExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test
     void shouldProduceHttp400WithFieldInfo() {
-        InvalidFormatException exception = buildExceptionWithPath(
+        InvalidDefinitionException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = mapper.toResponse(exception);
@@ -36,27 +36,13 @@ class InvalidFormatExceptionMapperTest {
         assertThat(response.getMediaType()).isEqualTo(HttpProblem.MEDIA_TYPE);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field")
+                .hasFieldOrPropertyWithValue("detail", "Invalid definition")
                 .hasFieldOrPropertyWithValue("parameters.field", "customFieldName");
     }
 
     @Test
-    void invalidFormatInsideCollectionShouldShowValidPath() {
-        InvalidFormatException exception = buildExceptionWithPath(
-                new JsonMappingException.Reference(this, "collection"),
-                new JsonMappingException.Reference(this, 2),
-                new JsonMappingException.Reference(this, "customFieldName"));
-
-        Response response = mapper.toResponse(exception);
-
-        assertThat(response.getEntity())
-                .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("parameters.field", "collection[2].customFieldName");
-    }
-
-    @Test
     void emptyPathShouldNotCrash() {
-        InvalidFormatException exception = buildExceptionWithPath();
+        InvalidDefinitionException exception = buildExceptionWithPath();
 
         Response response = mapper.toResponse(exception);
 
@@ -67,8 +53,9 @@ class InvalidFormatExceptionMapperTest {
 
     @Test
     void shouldSanitizeDetailByDefault() {
-        InvalidFormatExceptionMapper sanitizedMapper = new InvalidFormatExceptionMapper(registry, new DetailSanitizer(false));
-        InvalidFormatException exception = buildExceptionWithPath(
+        InvalidDefinitionExceptionMapper sanitizedMapper = new InvalidDefinitionExceptionMapper(registry,
+                new DetailSanitizer(false));
+        InvalidDefinitionException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = sanitizedMapper.toResponse(exception);
@@ -82,24 +69,23 @@ class InvalidFormatExceptionMapperTest {
 
     @Test
     void shouldPreserveDetailWhenIncludeDetails() {
-        InvalidFormatException exception = buildExceptionWithPath(
+        InvalidDefinitionException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = mapper.toResponse(exception);
 
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field");
+                .hasFieldOrPropertyWithValue("detail", "Invalid definition");
     }
 
-    private InvalidFormatException buildExceptionWithPath(JsonMappingException.Reference... pathSegments) {
-        InvalidFormatException exception = new InvalidFormatException(mock(JsonParser.class),
-                "Invalid format of the field", this, this.getClass());
+    private InvalidDefinitionException buildExceptionWithPath(JsonMappingException.Reference... pathSegments) {
+        InvalidDefinitionException exception = InvalidDefinitionException.from(mock(JsonParser.class),
+                "Invalid definition", (com.fasterxml.jackson.databind.JavaType) null);
 
         for (int i = pathSegments.length - 1; i >= 0; --i) {
             exception.prependPath(pathSegments[i]);
         }
         return exception;
     }
-
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JacksonFieldPathSerializerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JacksonFieldPathSerializerTest.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.httpproblem.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+class JacksonFieldPathSerializerTest {
+
+    @Test
+    void singleFieldName() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, "userName"));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("userName");
+    }
+
+    @Test
+    void nestedFieldPath() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, "address"),
+                new JsonMappingException.Reference(this, "city"));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("address.city");
+    }
+
+    @Test
+    void arrayIndexInPath() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, "items"),
+                new JsonMappingException.Reference(this, 2),
+                new JsonMappingException.Reference(this, "name"));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("items[2].name");
+    }
+
+    @Test
+    void emptyPathReturnsQuestionMark() {
+        assertThat(JacksonFieldPathSerializer.serializePath(Collections.emptyList())).isEqualTo("?");
+    }
+
+    @Test
+    void pathStartingWithArrayIndex() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, 0),
+                new JsonMappingException.Reference(this, "name"));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("[0].name");
+    }
+
+    @Test
+    void onlyArrayIndex() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, 5));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("[5]");
+    }
+
+    @Test
+    void consecutiveArrayIndices() {
+        List<JsonMappingException.Reference> path = List.of(
+                new JsonMappingException.Reference(this, "matrix"),
+                new JsonMappingException.Reference(this, 1),
+                new JsonMappingException.Reference(this, 3));
+
+        assertThat(JacksonFieldPathSerializer.serializePath(path)).isEqualTo("matrix[1][3]");
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.httpproblem.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -12,8 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
@@ -25,7 +23,7 @@ class JsonProcessingExceptionMapperTest {
 
     @Test
     void shouldProduceHttp400WithOriginalMessageWhenIncludeDetails() {
-        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, configWith(true));
+        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, new DetailSanitizer(true));
         JsonParseException exception = new JsonParseException("Unexpected end-of-input");
 
         Response response = mapper.toResponse(exception);
@@ -39,7 +37,7 @@ class JsonProcessingExceptionMapperTest {
 
     @Test
     void shouldSanitizeDetailByDefault() {
-        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, configWith(false));
+        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper(registry, new DetailSanitizer(false));
         JsonParseException exception = new JsonParseException("Unexpected end-of-input");
 
         Response response = mapper.toResponse(exception);
@@ -47,12 +45,6 @@ class JsonProcessingExceptionMapperTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", JsonProcessingExceptionMapper.SANITIZED_DETAIL);
-    }
-
-    private static ProblemRuntimeFixedConfig configWith(boolean includeDetails) {
-        ProblemRuntimeFixedConfig config = mock(ProblemRuntimeFixedConfig.class);
-        when(config.includeDetails()).thenReturn(includeDetails);
-        return config;
+                .hasFieldOrPropertyWithValue("detail", DetailSanitizer.SANITIZED_DETAIL);
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.HttpProblem;
@@ -19,15 +19,15 @@ import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
 
-class InvalidFormatExceptionMapperTest {
+class MismatchedInputExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
             List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
-    InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry, new DetailSanitizer(true));
+    MismatchedInputExceptionMapper mapper = new MismatchedInputExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test
     void shouldProduceHttp400WithFieldInfo() {
-        InvalidFormatException exception = buildExceptionWithPath(
+        MismatchedInputException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = mapper.toResponse(exception);
@@ -36,13 +36,13 @@ class InvalidFormatExceptionMapperTest {
         assertThat(response.getMediaType()).isEqualTo(HttpProblem.MEDIA_TYPE);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field")
+                .hasFieldOrPropertyWithValue("detail", "Mismatched input")
                 .hasFieldOrPropertyWithValue("parameters.field", "customFieldName");
     }
 
     @Test
-    void invalidFormatInsideCollectionShouldShowValidPath() {
-        InvalidFormatException exception = buildExceptionWithPath(
+    void mismatchedInputInsideCollectionShouldShowValidPath() {
+        MismatchedInputException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "collection"),
                 new JsonMappingException.Reference(this, 2),
                 new JsonMappingException.Reference(this, "customFieldName"));
@@ -56,7 +56,7 @@ class InvalidFormatExceptionMapperTest {
 
     @Test
     void emptyPathShouldNotCrash() {
-        InvalidFormatException exception = buildExceptionWithPath();
+        MismatchedInputException exception = buildExceptionWithPath();
 
         Response response = mapper.toResponse(exception);
 
@@ -67,8 +67,9 @@ class InvalidFormatExceptionMapperTest {
 
     @Test
     void shouldSanitizeDetailByDefault() {
-        InvalidFormatExceptionMapper sanitizedMapper = new InvalidFormatExceptionMapper(registry, new DetailSanitizer(false));
-        InvalidFormatException exception = buildExceptionWithPath(
+        MismatchedInputExceptionMapper sanitizedMapper = new MismatchedInputExceptionMapper(registry,
+                new DetailSanitizer(false));
+        MismatchedInputException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = sanitizedMapper.toResponse(exception);
@@ -82,24 +83,23 @@ class InvalidFormatExceptionMapperTest {
 
     @Test
     void shouldPreserveDetailWhenIncludeDetails() {
-        InvalidFormatException exception = buildExceptionWithPath(
+        MismatchedInputException exception = buildExceptionWithPath(
                 new JsonMappingException.Reference(this, "customFieldName"));
 
         Response response = mapper.toResponse(exception);
 
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", "Invalid format of the field");
+                .hasFieldOrPropertyWithValue("detail", "Mismatched input");
     }
 
-    private InvalidFormatException buildExceptionWithPath(JsonMappingException.Reference... pathSegments) {
-        InvalidFormatException exception = new InvalidFormatException(mock(JsonParser.class),
-                "Invalid format of the field", this, this.getClass());
+    private MismatchedInputException buildExceptionWithPath(JsonMappingException.Reference... pathSegments) {
+        MismatchedInputException exception = MismatchedInputException.from(mock(JsonParser.class),
+                this.getClass(), "Mismatched input");
 
         for (int i = pathSegments.length - 1; i >= 0; --i) {
             exception.prependPath(pathSegments[i]);
         }
         return exception;
     }
-
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.httpproblem.jsonb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -11,8 +9,8 @@ import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
@@ -24,7 +22,7 @@ class JsonbExceptionMapperTest {
 
     @Test
     void shouldProduceHttp400WithCauseMessageWhenIncludeDetails() {
-        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, configWith(true));
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, new DetailSanitizer(true));
         JsonbException exception = new JsonbException("wrapper", new RuntimeException("Invalid UUID string: ABC"));
 
         Response response = mapper.toResponse(exception);
@@ -38,7 +36,7 @@ class JsonbExceptionMapperTest {
 
     @Test
     void shouldSanitizeDetailByDefault() {
-        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, configWith(false));
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, new DetailSanitizer(false));
         JsonbException exception = new JsonbException("wrapper", new RuntimeException("Invalid UUID string: ABC"));
 
         Response response = mapper.toResponse(exception);
@@ -46,12 +44,12 @@ class JsonbExceptionMapperTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", JsonbExceptionMapper.SANITIZED_DETAIL);
+                .hasFieldOrPropertyWithValue("detail", DetailSanitizer.SANITIZED_DETAIL);
     }
 
     @Test
     void shouldPreserveDetailWhenIncludeDetails() {
-        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, configWith(true));
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, new DetailSanitizer(true));
         JsonbException exception = new JsonbException("wrapper", new RuntimeException("Internal error details"));
 
         Response response = mapper.toResponse(exception);
@@ -63,7 +61,7 @@ class JsonbExceptionMapperTest {
 
     @Test
     void shouldSanitizeEvenWithNoCause() {
-        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, configWith(false));
+        JsonbExceptionMapper mapper = new JsonbExceptionMapper(registry, new DetailSanitizer(false));
         JsonbException exception = new JsonbException("wrapper");
 
         Response response = mapper.toResponse(exception);
@@ -71,12 +69,6 @@ class JsonbExceptionMapperTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", JsonbExceptionMapper.SANITIZED_DETAIL);
-    }
-
-    private static ProblemRuntimeFixedConfig configWith(boolean includeDetails) {
-        ProblemRuntimeFixedConfig config = mock(ProblemRuntimeFixedConfig.class);
-        when(config.includeDetails()).thenReturn(includeDetails);
-        return config;
+                .hasFieldOrPropertyWithValue("detail", DetailSanitizer.SANITIZED_DETAIL);
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.httpproblem.jsonb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -12,8 +10,8 @@ import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.HttpProblem;
-import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
@@ -22,7 +20,7 @@ class RestEasyClassicJsonbExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
             List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
-    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry, configWith(true));
+    RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test
     void processingExceptionShouldProduceHttp500() {
@@ -45,7 +43,7 @@ class RestEasyClassicJsonbExceptionMapperTest {
     @Test
     void shouldSanitizeDetailByDefault() {
         RestEasyClassicJsonbExceptionMapper sanitizedMapper = new RestEasyClassicJsonbExceptionMapper(registry,
-                configWith(false));
+                new DetailSanitizer(false));
         ProcessingException exception = new ProcessingException(new JsonbException("Internal class details leaked"));
 
         Response response = sanitizedMapper.toResponse(exception);
@@ -53,7 +51,7 @@ class RestEasyClassicJsonbExceptionMapperTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
-                .hasFieldOrPropertyWithValue("detail", RestEasyClassicJsonbExceptionMapper.SANITIZED_DETAIL);
+                .hasFieldOrPropertyWithValue("detail", DetailSanitizer.SANITIZED_DETAIL);
     }
 
     @Test
@@ -65,11 +63,5 @@ class RestEasyClassicJsonbExceptionMapperTest {
         assertThat(response.getEntity())
                 .isInstanceOf(HttpProblem.class)
                 .hasFieldOrPropertyWithValue("detail", "Something is wrong");
-    }
-
-    private static ProblemRuntimeFixedConfig configWith(boolean includeDetails) {
-        ProblemRuntimeFixedConfig config = mock(ProblemRuntimeFixedConfig.class);
-        when(config.includeDetails()).thenReturn(includeDetails);
-        return config;
     }
 }


### PR DESCRIPTION
Two `JsonMappingException` subclasses - `MismatchedInputException` and `InvalidDefinitionException` - were not covered by the extension, so they fell through to Jackson's own mappers and bypassed the http-problem pipeline (logging, MDC injection, detail sanitization, RFC 9457 response format).

This adds dedicated mappers for both exception types following the same pattern as `InvalidFormatExceptionMapper`, including field path extraction and the `include-details` sanitization config. It also extracts the shared field path serialization logic into a `JacksonFieldPathSerializer` utility to avoid duplication across the three mappers that need it.

Both mappers can be individually disabled via `quarkus.http-problem.mapper.mismatched-input-exception.enabled=false` and `quarkus.http-problem.mapper.invalid-definition-exception.enabled=false`.

Fixes #317