### PR TITLE
Add configurable log levels and stack trace thresholds

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemBuildConfig.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.httpproblem.deployment;
 
+import java.util.List;
 import java.util.Map;
 
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogLevel;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -54,5 +56,43 @@ public interface ProblemBuildConfig {
          */
         @WithDefault("true")
         boolean enabled();
+    }
+
+    /**
+     * Logging configuration for HTTP problem responses.
+     */
+    @WithName("logging")
+    LoggingConfig logging();
+
+    interface LoggingConfig {
+        /**
+         * Whether problem logging is enabled.
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Log level per HTTP status code class ({@code 4xx}, {@code 5xx}) or exact status code ({@code 401}).
+         * <p>
+         * Exact codes take precedence over status classes. Unconfigured classes default to {@code INFO}.
+         * <p>
+         * Example:
+         *
+         * <pre>
+         * quarkus.http-problem.logging.level.4xx=DEBUG
+         * quarkus.http-problem.logging.level.5xx=ERROR
+         * quarkus.http-problem.logging.level.401=WARN
+         * </pre>
+         */
+        @WithName("level")
+        Map<String, ProblemLogLevel> level();
+
+        /**
+         * Comma-separated list of status code classes ({@code 5xx}) or exact codes ({@code 403})
+         * for which the original exception stack trace is included in the log output.
+         */
+        @WithDefault("5xx")
+        @WithName("include-stack-trace")
+        List<String> includeStackTrace();
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -1,13 +1,16 @@
 package io.quarkiverse.httpproblem.deployment;
 
 import static io.quarkiverse.httpproblem.deployment.ExceptionMapperDefinition.mapper;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Priorities;
 
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -18,13 +21,18 @@ import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLogLevel;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkiverse.httpproblem.postprocessing.ProblemPostProcessor;
+import io.quarkiverse.httpproblem.postprocessing.ProblemRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -33,6 +41,7 @@ import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 
 public class ProblemProcessor {
@@ -226,10 +235,30 @@ public class ProblemProcessor {
     @BuildStep
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(PostProcessorsRegistry.class));
-        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemLogger.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ProblemDefaultsProvider.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(MdcPropertiesInjector.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(DetailSanitizer.class));
+        // ProblemLogger is registered as a synthetic bean via setupLogging() to receive configuration
+    }
+
+    @Record(STATIC_INIT)
+    @BuildStep
+    SyntheticBeanBuildItem setupLogging(ProblemRecorder recorder, ProblemBuildConfig config) {
+        ProblemBuildConfig.LoggingConfig logging = config.logging();
+        if (!logging.enabled()) {
+            return null;
+        }
+
+        Map<String, ProblemLogLevel> levels = new LinkedHashMap<>(ProblemLoggingConfig.DEFAULT_LEVELS);
+        levels.putAll(logging.level());
+
+        RuntimeValue<ProblemLogger> runtimeValue = recorder.createProblemLogger(levels, logging.includeStackTrace());
+        return SyntheticBeanBuildItem.configure(ProblemLogger.class)
+                .scope(Singleton.class)
+                .addType(ProblemPostProcessor.class)
+                .runtimeValue(runtimeValue)
+                .unremovable()
+                .done();
     }
 
     @BuildStep

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogLevel.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogLevel.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.httpproblem.postprocessing;
+
+import org.jboss.logging.Logger;
+
+public enum ProblemLogLevel {
+
+    OFF {
+        @Override
+        public void log(Logger logger, String message) {
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+        }
+    },
+    TRACE {
+        @Override
+        public void log(Logger logger, String message) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(message);
+            }
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(message, cause);
+            }
+        }
+    },
+    DEBUG {
+        @Override
+        public void log(Logger logger, String message) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(message);
+            }
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(message, cause);
+            }
+        }
+    },
+    INFO {
+        @Override
+        public void log(Logger logger, String message) {
+            if (logger.isInfoEnabled()) {
+                logger.info(message);
+            }
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+            if (logger.isInfoEnabled()) {
+                logger.info(message, cause);
+            }
+        }
+    },
+    WARN {
+        @Override
+        public void log(Logger logger, String message) {
+            if (logger.isEnabled(Logger.Level.WARN)) {
+                logger.warn(message);
+            }
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+            if (logger.isEnabled(Logger.Level.WARN)) {
+                logger.warn(message, cause);
+            }
+        }
+    },
+    ERROR {
+        @Override
+        public void log(Logger logger, String message) {
+            if (logger.isEnabled(Logger.Level.ERROR)) {
+                logger.error(message);
+            }
+        }
+
+        @Override
+        public void log(Logger logger, String message, Throwable cause) {
+            if (logger.isEnabled(Logger.Level.ERROR)) {
+                logger.error(message, cause);
+            }
+        }
+    };
+
+    public abstract void log(Logger logger, String message);
+
+    public abstract void log(Logger logger, String message, Throwable cause);
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -2,50 +2,47 @@ package io.quarkiverse.httpproblem.postprocessing;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 
-@Singleton
 public class ProblemLogger implements ProblemPostProcessor {
 
     private final Logger logger;
+    private final ProblemLoggingConfig config;
 
-    public ProblemLogger() {
-        this(Logger.getLogger("http-problem"));
+    public ProblemLogger(ProblemLoggingConfig config) {
+        this(Logger.getLogger("http-problem"), config);
     }
 
-    ProblemLogger(Logger logger) {
+    ProblemLogger(Logger logger, ProblemLoggingConfig config) {
         this.logger = logger;
+        this.config = config;
     }
 
     @Override
     public HttpProblem apply(HttpProblem problem, ProblemContext context) {
-        if (problem.getStatusCode() >= 500) {
-            if (logger.isEnabled(Logger.Level.ERROR)) {
-                logger.error(serialize(problem), context.cause);
-            }
+        int statusCode = problem.getStatusCode();
+        ProblemLogLevel level = config.resolveLevel(statusCode);
+        String message = serialize(problem);
+        if (config.includeStackTrace(statusCode)) {
+            level.log(logger, message, context.cause);
         } else {
-            if (logger.isInfoEnabled()) {
-                logger.info(serialize(problem));
-            }
+            level.log(logger, message);
         }
         return problem;
     }
 
     private String serialize(HttpProblem problem) {
         Stream<String> basicFields = Stream.of(
-                ("status=" + problem.getStatusCode()),
-                (problem.getTitle() == null) ? null : ("title=\"" + problem.getTitle() + "\""),
-                (problem.getDetail() == null) ? null : ("detail=\"" + problem.getDetail() + "\""),
-                (problem.getInstance() == null) ? null : ("instance=\"" + problem.getInstance() + "\""),
-                (problem.getType() == null) ? null : "type=" + problem.getType().toString());
+                "status=" + problem.getStatusCode(),
+                problem.getTitle() == null ? null : "title=\"" + problem.getTitle() + "\"",
+                problem.getDetail() == null ? null : "detail=\"" + problem.getDetail() + "\"",
+                problem.getInstance() == null ? null : "instance=\"" + problem.getInstance() + "\"",
+                problem.getType() == null ? null : "type=" + problem.getType());
 
         Stream<String> parameters = problem.getParameters().entrySet().stream().map(this::serializeParameter);
 
@@ -55,16 +52,15 @@ public class ProblemLogger implements ProblemPostProcessor {
     }
 
     private String serializeParameter(Map.Entry<String, Object> param) {
-        String serializedValue = Optional.ofNullable(param.getValue())
-                .map(value -> {
-                    if (value instanceof String) {
-                        return "\"" + value + "\"";
-                    } else {
-                        return value.toString();
-                    }
-                })
-                .orElse("null");
-
+        Object value = param.getValue();
+        String serializedValue;
+        if (value == null) {
+            serializedValue = "null";
+        } else if (value instanceof String) {
+            serializedValue = "\"" + value + "\"";
+        } else {
+            serializedValue = value.toString();
+        }
         return param.getKey() + "=" + serializedValue;
     }
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggingConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggingConfig.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.httpproblem.postprocessing;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+public final class ProblemLoggingConfig {
+
+    public static final Map<String, ProblemLogLevel> DEFAULT_LEVELS = Map.of(
+            "4xx", ProblemLogLevel.INFO,
+            "5xx", ProblemLogLevel.ERROR);
+
+    public static final List<String> DEFAULT_STACK_TRACE_PATTERNS = List.of("5xx");
+
+    private final Map<Integer, ProblemLogLevel> classLevels;
+    private final Map<Integer, ProblemLogLevel> exactLevels;
+    private final Set<Integer> stackTraceClasses;
+    private final Set<Integer> stackTraceCodes;
+
+    public static ProblemLoggingConfig defaults() {
+        return new ProblemLoggingConfig(DEFAULT_LEVELS, DEFAULT_STACK_TRACE_PATTERNS);
+    }
+
+    public ProblemLoggingConfig(Map<String, ProblemLogLevel> levels, List<String> stackTracePatterns) {
+        this.classLevels = new HashMap<>();
+        this.exactLevels = new HashMap<>();
+        this.stackTraceClasses = new HashSet<>();
+        this.stackTraceCodes = new HashSet<>();
+
+        for (Map.Entry<String, ProblemLogLevel> entry : levels.entrySet()) {
+            String key = entry.getKey().toLowerCase(Locale.ROOT);
+            if (isStatusClass(key)) {
+                classLevels.put(Character.getNumericValue(key.charAt(0)), entry.getValue());
+            } else {
+                exactLevels.put(parseStatusCode(entry.getKey(),
+                        "Invalid logging level key '%s': expected a status class (e.g. 4xx) or exact code (e.g. 401)"),
+                        entry.getValue());
+            }
+        }
+
+        for (String pattern : stackTracePatterns) {
+            String trimmed = pattern.trim().toLowerCase(Locale.ROOT);
+            if (isStatusClass(trimmed)) {
+                stackTraceClasses.add(Character.getNumericValue(trimmed.charAt(0)));
+            } else {
+                stackTraceCodes.add(parseStatusCode(pattern.trim(),
+                        "Invalid include-stack-trace pattern '%s': expected a status class (e.g. 5xx) or exact code (e.g. 403)"));
+            }
+        }
+    }
+
+    public ProblemLogLevel resolveLevel(int statusCode) {
+        ProblemLogLevel exact = exactLevels.get(statusCode);
+        if (exact != null) {
+            return exact;
+        }
+        return classLevels.getOrDefault(statusCode / 100, ProblemLogLevel.INFO);
+    }
+
+    public boolean includeStackTrace(int statusCode) {
+        return stackTraceCodes.contains(statusCode) || stackTraceClasses.contains(statusCode / 100);
+    }
+
+    private static boolean isStatusClass(String pattern) {
+        return pattern.length() == 3
+                && pattern.charAt(0) >= '1' && pattern.charAt(0) <= '5'
+                && pattern.charAt(1) == 'x'
+                && pattern.charAt(2) == 'x';
+    }
+
+    private static int parseStatusCode(String value, String errorFormat) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, errorFormat, value));
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.httpproblem.postprocessing;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class ProblemRecorder {
+
+    public RuntimeValue<ProblemLogger> createProblemLogger(Map<String, ProblemLogLevel> levels,
+            List<String> stackTracePatterns) {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(levels, stackTracePatterns);
+        return new RuntimeValue<>(new ProblemLogger(config));
+    }
+
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemMapperTest.java
@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class HttpProblemMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     HttpProblemMapper mapper = new HttpProblemMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ProblemMapperBenchmark.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ProblemMapperBenchmark.java
@@ -34,6 +34,7 @@ import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 /**
  * JMH benchmark for selected exception Mapper with all post-processors enabled + junit runner test for convenience.
@@ -59,7 +60,7 @@ public class ProblemMapperBenchmark {
         @Setup(Level.Trial)
         public void initMapper() {
             PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
-                    new ProblemLogger(),
+                    new ProblemLogger(ProblemLoggingConfig.defaults()),
                     new ProblemDefaultsProvider(),
                     new MdcPropertiesInjector(Set.of("uuid"))));
             mapper = new HttpProblemMapper(registry);

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ZalandoProblemMapperTest.java
@@ -14,11 +14,12 @@ import org.zalando.problem.ThrowableProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class ZalandoProblemMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     ZalandoProblemMapper mapper = new ZalandoProblemMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidDefinitionExceptionMapperTest.java
@@ -18,11 +18,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class InvalidDefinitionExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     InvalidDefinitionExceptionMapper mapper = new InvalidDefinitionExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/InvalidFormatExceptionMapperTest.java
@@ -18,11 +18,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class InvalidFormatExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     InvalidFormatExceptionMapper mapper = new InvalidFormatExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/JsonProcessingExceptionMapperTest.java
@@ -15,11 +15,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class JsonProcessingExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
 
     @Test
     void shouldProduceHttp400WithOriginalMessageWhenIncludeDetails() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/MismatchedInputExceptionMapperTest.java
@@ -18,11 +18,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class MismatchedInputExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     MismatchedInputExceptionMapper mapper = new MismatchedInputExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jackson/UnrecognizedPropertyExceptionMapperTest.java
@@ -17,11 +17,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class UnrecognizedPropertyExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     UnrecognizedPropertyExceptionMapper mapper = new UnrecognizedPropertyExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/NotFoundExceptionMapperTest.java
@@ -12,11 +12,12 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class NotFoundExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     NotFoundExceptionMapper mapper = new NotFoundExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jaxrs/WebApplicationExceptionMapperTest.java
@@ -19,13 +19,14 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class WebApplicationExceptionMapperTest {
 
     static final MediaType MEDIA_TYPE_SHOULD_BE_IGNORED = MediaType.TEXT_PLAIN_TYPE;
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/JsonbExceptionMapperTest.java
@@ -14,11 +14,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class JsonbExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
 
     @Test
     void shouldProduceHttp400WithCauseMessageWhenIncludeDetails() {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/jsonb/RestEasyClassicJsonbExceptionMapperTest.java
@@ -15,11 +15,12 @@ import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class RestEasyClassicJsonbExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     RestEasyClassicJsonbExceptionMapper mapper = new RestEasyClassicJsonbExceptionMapper(registry, new DetailSanitizer(true));
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
@@ -2,7 +2,9 @@ package io.quarkiverse.httpproblem.postprocessing;
 
 import static io.quarkiverse.httpproblem.postprocessing.ProblemContextMother.simpleContext;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -11,6 +13,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,13 +25,18 @@ import io.quarkiverse.httpproblem.validation.Violation;
 
 class ProblemLoggerTest {
 
+    static final ProblemLoggingConfig DEFAULT_CONFIG = ProblemLoggingConfig.defaults();
+
     Logger logger = mock(Logger.class);
-    ProblemLogger processor = new ProblemLogger(logger);
+    ProblemLogger processor = new ProblemLogger(logger, DEFAULT_CONFIG);
 
     @BeforeEach
     void init() {
         when(logger.isEnabled(Logger.Level.ERROR)).thenReturn(true);
         when(logger.isInfoEnabled()).thenReturn(true);
+        when(logger.isEnabled(Logger.Level.WARN)).thenReturn(true);
+        when(logger.isDebugEnabled()).thenReturn(true);
+        when(logger.isTraceEnabled()).thenReturn(true);
     }
 
     @Test
@@ -115,6 +124,80 @@ class ProblemLoggerTest {
         processor.apply(problem, ProblemContextMother.withCause(cause));
 
         verify(logger, never()).error(anyString(), any(Throwable.class));
+    }
+
+    @Test
+    void shouldLogAtWarnWhenConfiguredForStatusClass() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.WARN, "5xx", ProblemLogLevel.ERROR),
+                List.of("5xx"));
+        ProblemLogger warnProcessor = new ProblemLogger(logger, config);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("your fault")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        warnProcessor.apply(problem, simpleContext());
+
+        verify(logger).warn("status=400, title=\"your fault\"");
+    }
+
+    @Test
+    void shouldLogAtExactCodeLevelOverridingClass() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.INFO, "401", ProblemLogLevel.WARN),
+                List.of("5xx"));
+        ProblemLogger overrideProcessor = new ProblemLogger(logger, config);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("unauthorized")
+                .withStatus(UNAUTHORIZED)
+                .build();
+
+        overrideProcessor.apply(problem, simpleContext());
+
+        verify(logger).warn("status=401, title=\"unauthorized\"");
+        verify(logger, never()).info(anyString());
+    }
+
+    @Test
+    void shouldIncludeStackTraceForExactCode() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.WARN),
+                List.of("403"));
+        ProblemLogger stackProcessor = new ProblemLogger(logger, config);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("forbidden")
+                .withStatus(FORBIDDEN)
+                .build();
+        RuntimeException cause = new RuntimeException("denied");
+
+        stackProcessor.apply(problem, ProblemContextMother.withCause(cause));
+
+        verify(logger).warn("status=403, title=\"forbidden\"", cause);
+    }
+
+    @Test
+    void shouldNotLogWhenLevelIsOff() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.OFF),
+                List.of());
+        ProblemLogger offProcessor = new ProblemLogger(logger, config);
+
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("your fault")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        offProcessor.apply(problem, simpleContext());
+
+        verify(logger, never()).info(anyString());
+        verify(logger, never()).warn(anyString());
+        verify(logger, never()).error(anyString());
+        verify(logger, never()).debug(anyString());
+        verify(logger, never()).trace(anyString());
     }
 
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggingConfigTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggingConfigTest.java
@@ -1,0 +1,114 @@
+package io.quarkiverse.httpproblem.postprocessing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ProblemLoggingConfigTest {
+
+    @Test
+    void shouldResolveClassLevel() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.WARN, "5xx", ProblemLogLevel.ERROR),
+                List.of());
+
+        assertThat(config.resolveLevel(400)).isEqualTo(ProblemLogLevel.WARN);
+        assertThat(config.resolveLevel(404)).isEqualTo(ProblemLogLevel.WARN);
+        assertThat(config.resolveLevel(500)).isEqualTo(ProblemLogLevel.ERROR);
+        assertThat(config.resolveLevel(503)).isEqualTo(ProblemLogLevel.ERROR);
+    }
+
+    @Test
+    void shouldResolveExactCodeOverClass() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4xx", ProblemLogLevel.INFO, "401", ProblemLogLevel.WARN, "403", ProblemLogLevel.ERROR),
+                List.of());
+
+        assertThat(config.resolveLevel(400)).isEqualTo(ProblemLogLevel.INFO);
+        assertThat(config.resolveLevel(401)).isEqualTo(ProblemLogLevel.WARN);
+        assertThat(config.resolveLevel(403)).isEqualTo(ProblemLogLevel.ERROR);
+        assertThat(config.resolveLevel(404)).isEqualTo(ProblemLogLevel.INFO);
+    }
+
+    @Test
+    void shouldFallbackToInfoForUnconfiguredClass() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("5xx", ProblemLogLevel.ERROR),
+                List.of());
+
+        assertThat(config.resolveLevel(400)).isEqualTo(ProblemLogLevel.INFO);
+        assertThat(config.resolveLevel(302)).isEqualTo(ProblemLogLevel.INFO);
+    }
+
+    @Test
+    void shouldIncludeStackTraceForClass() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of(),
+                List.of("5xx"));
+
+        assertThat(config.includeStackTrace(500)).isTrue();
+        assertThat(config.includeStackTrace(503)).isTrue();
+        assertThat(config.includeStackTrace(400)).isFalse();
+    }
+
+    @Test
+    void shouldIncludeStackTraceForExactCode() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of(),
+                List.of("5xx", "403"));
+
+        assertThat(config.includeStackTrace(500)).isTrue();
+        assertThat(config.includeStackTrace(403)).isTrue();
+        assertThat(config.includeStackTrace(401)).isFalse();
+    }
+
+    @Test
+    void shouldExcludeStackTraceWhenEmpty() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of(),
+                List.of());
+
+        assertThat(config.includeStackTrace(500)).isFalse();
+        assertThat(config.includeStackTrace(400)).isFalse();
+    }
+
+    @Test
+    void shouldHandleMixedCasePatterns() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of("4XX", ProblemLogLevel.WARN),
+                List.of("5XX"));
+
+        assertThat(config.resolveLevel(400)).isEqualTo(ProblemLogLevel.WARN);
+        assertThat(config.includeStackTrace(500)).isTrue();
+    }
+
+    @Test
+    void shouldHandleStackTracePatternsWithWhitespace() {
+        ProblemLoggingConfig config = new ProblemLoggingConfig(
+                Map.of(),
+                List.of(" 5xx ", " 403 "));
+
+        assertThat(config.includeStackTrace(500)).isTrue();
+        assertThat(config.includeStackTrace(403)).isTrue();
+    }
+
+    @Test
+    void shouldRejectInvalidLevelKey() {
+        assertThatThrownBy(() -> new ProblemLoggingConfig(Map.of("abc", ProblemLogLevel.WARN), List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abc")
+                .hasMessageContaining("expected a status class");
+    }
+
+    @Test
+    void shouldRejectInvalidStackTracePattern() {
+        assertThatThrownBy(() -> new ProblemLoggingConfig(Map.of(), List.of("abc")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abc")
+                .hasMessageContaining("expected a status class");
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationCompletionExceptionMapperTest.java
@@ -11,12 +11,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkus.security.AuthenticationCompletionException;
 
 class AuthenticationCompletionExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     AuthenticationCompletionExceptionMapper mapper = new AuthenticationCompletionExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationFailedExceptionMapperTest.java
@@ -12,13 +12,14 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
 class AuthenticationFailedExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     CurrentVertxRequest currentVertxRequest = mock(CurrentVertxRequest.class);
     AuthenticationFailedExceptionMapper mapper = new AuthenticationFailedExceptionMapper(registry, currentVertxRequest);
 

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/AuthenticationRedirectExceptionMapperTest.java
@@ -12,12 +12,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkus.security.AuthenticationRedirectException;
 
 class AuthenticationRedirectExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     AuthenticationRedirectExceptionMapper mapper = new AuthenticationRedirectExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/ForbiddenExceptionMapperTest.java
@@ -11,12 +11,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkus.security.ForbiddenException;
 
 class ForbiddenExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     ForbiddenExceptionMapper mapper = new ForbiddenExceptionMapper(registry);
 
     @Test

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/UnauthorizedExceptionMapperTest.java
@@ -12,13 +12,14 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
 class UnauthorizedExceptionMapperTest {
 
     PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     CurrentVertxRequest currentVertxRequest = mock(CurrentVertxRequest.class);
     UnauthorizedExceptionMapper mapper = new UnauthorizedExceptionMapper(registry, currentVertxRequest);
 

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ConstraintViolationExceptionMapperTest.java
@@ -55,6 +55,7 @@ import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
 import io.quarkiverse.httpproblem.postprocessing.ProblemLogger;
+import io.quarkiverse.httpproblem.postprocessing.ProblemLoggingConfig;
 
 class ConstraintViolationExceptionMapperTest {
 
@@ -64,7 +65,7 @@ class ConstraintViolationExceptionMapperTest {
     final String TOO_SHORT_COMPANY_NAME = "CO";
 
     final PostProcessorsRegistry registry = new PostProcessorsRegistry(
-            List.of(new ProblemLogger(), new ProblemDefaultsProvider()));
+            List.of(new ProblemLogger(ProblemLoggingConfig.defaults()), new ProblemDefaultsProvider()));
     final ProblemRuntimeFixedConfig runtimeConfig = constraintViolationConfig(400, "Bad Request");
     final ConstraintViolationExceptionMapper mapper = new ConstraintViolationExceptionMapper(registry, runtimeConfig);
     final StubResourceInfo resourceInfo = StubResourceInfo.withDefaultValidator();


### PR DESCRIPTION
The ProblemLogger previously hardcoded its behavior - 4xx at INFO without stack traces, 5xx at ERROR with stack traces. This makes both the log level and stack trace inclusion configurable per status code class or exact code, via build-time configuration:

```properties
quarkus.http-problem.logging.enabled=true
quarkus.http-problem.logging.level.4xx=INFO
quarkus.http-problem.logging.level.5xx=ERROR
quarkus.http-problem.logging.level.401=WARN
quarkus.http-problem.logging.include-stack-trace=5xx,403
```

Exact codes take precedence over status classes. Logging can be disabled entirely with `logging.enabled=false`. Defaults preserve the existing behavior (4xx=INFO, 5xx=ERROR, stack traces for 5xx only), so this is fully backwards compatible.

ProblemLogger is now created as a synthetic bean via the recorder (following the MdcPropertiesInjector pattern) so it can receive the resolved configuration at build time.

Fixes #552
Fixes #512