### PR TITLE
Catch exceptions from individual post-processors to prevent pipeline crashes

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
@@ -6,6 +6,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.httpproblem.HttpProblem;
 
 /**
@@ -14,6 +16,8 @@ import io.quarkiverse.httpproblem.HttpProblem;
  */
 @ApplicationScoped
 public class PostProcessorsRegistry {
+
+    private static final Logger LOG = Logger.getLogger(PostProcessorsRegistry.class);
 
     private final List<ProblemPostProcessor> processors;
 
@@ -33,7 +37,12 @@ public class PostProcessorsRegistry {
     public HttpProblem applyPostProcessing(HttpProblem problem, ProblemContext context) {
         HttpProblem finalProblem = problem;
         for (ProblemPostProcessor processor : processors) {
-            finalProblem = processor.apply(finalProblem, context);
+            try {
+                finalProblem = processor.apply(finalProblem, context);
+            } catch (Exception e) {
+                LOG.warnf(e, "Post-processor %s failed for status %d, skipping",
+                        processor.getClass().getName(), finalProblem.getStatusCode());
+            }
         }
         return finalProblem;
     }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistryTest.java
@@ -44,8 +44,62 @@ class PostProcessorsRegistryTest {
         assertThat(invocations).containsExactly(HIGHEST, MEDIUM, MEDIUM, MEDIUM);
     }
 
+    @Test
+    void shouldSkipFailingProcessorAndContinue() {
+        PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
+                processorWithPriority(HIGHEST),
+                failingProcessor(MEDIUM),
+                processorWithPriority(LOW)));
+
+        HttpProblem result = registry.applyPostProcessing(badRequestProblem(), simpleContext());
+
+        assertThat(invocations).containsExactly(HIGHEST, LOW);
+        assertThat(result.getStatusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void shouldPreserveProblemStateWhenProcessorFails() {
+        ProblemPostProcessor modifyThenFail = new ProblemPostProcessor() {
+            @Override
+            public HttpProblem apply(HttpProblem problem, ProblemContext context) {
+                invocations.add(MEDIUM);
+                throw new RuntimeException("boom");
+            }
+
+            @Override
+            public int priority() {
+                return MEDIUM;
+            }
+        };
+
+        PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of(
+                processorWithPriority(HIGHEST),
+                modifyThenFail,
+                processorWithPriority(LOW)));
+
+        HttpProblem original = badRequestProblem();
+        HttpProblem result = registry.applyPostProcessing(original, simpleContext());
+
+        assertThat(invocations).containsExactly(HIGHEST, MEDIUM, LOW);
+        assertThat(result).isSameAs(original);
+    }
+
     ProblemPostProcessor processorWithPriority(int priority) {
         return new TestProcessor(priority);
+    }
+
+    ProblemPostProcessor failingProcessor(int priority) {
+        return new ProblemPostProcessor() {
+            @Override
+            public HttpProblem apply(HttpProblem problem, ProblemContext context) {
+                throw new RuntimeException("processor failed");
+            }
+
+            @Override
+            public int priority() {
+                return priority;
+            }
+        };
     }
 
     class TestProcessor implements ProblemPostProcessor {


### PR DESCRIPTION
If any ProblemPostProcessor.apply() throws - whether from a user-provided processor, ProblemLogger (e.g. a parameter's toString() blowing up), or MdcPropertiesInjector - the exception previously propagated uncaught through ExceptionMapperBase.toResponse(). The original mapped HttpProblem was lost entirely, and the user got an uncontrolled 500 instead of a proper application/problem+json response.

The registry now wraps each processor invocation in a try-catch, logs a warning identifying the failing processor, and continues with the remaining processors. A single misbehaving post-processor can no longer sabotage the entire error mapping pipeline.

Fixes #642