### PR TITLE
Migrate all logging from SLF4J to JBoss Logging

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -11,8 +11,7 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.Priorities;
 
 import org.eclipse.microprofile.openapi.OASFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
 import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
@@ -231,6 +230,6 @@ public class ProblemProcessor {
     }
 
     protected Logger logger() {
-        return LoggerFactory.getLogger(FEATURE_NAME);
+        return Logger.getLogger(FEATURE_NAME);
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
@@ -9,10 +9,10 @@ import static org.mockito.Mockito.verify;
 import java.util.Collections;
 import java.util.Map;
 
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.slf4j.Logger;
 
 import io.quarkus.deployment.Capabilities;
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -8,8 +8,7 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Singleton;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 
@@ -19,7 +18,7 @@ public class ProblemLogger implements ProblemPostProcessor {
     private final Logger logger;
 
     public ProblemLogger() {
-        this(LoggerFactory.getLogger("http-problem"));
+        this(Logger.getLogger("http-problem"));
     }
 
     ProblemLogger(Logger logger) {
@@ -29,7 +28,7 @@ public class ProblemLogger implements ProblemPostProcessor {
     @Override
     public HttpProblem apply(HttpProblem problem, ProblemContext context) {
         if (problem.getStatusCode() >= 500) {
-            if (logger.isErrorEnabled()) {
+            if (logger.isEnabled(Logger.Level.ERROR)) {
                 logger.error(serialize(problem), context.cause);
             }
         } else {

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
@@ -12,9 +12,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
 
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkiverse.httpproblem.validation.Violation;
@@ -26,7 +26,7 @@ class ProblemLoggerTest {
 
     @BeforeEach
     void init() {
-        when(logger.isErrorEnabled()).thenReturn(true);
+        when(logger.isEnabled(Logger.Level.ERROR)).thenReturn(true);
         when(logger.isInfoEnabled()).thenReturn(true);
     }
 
@@ -73,7 +73,7 @@ class ProblemLoggerTest {
 
     @Test
     void shouldLog4xxAtInfoWhenErrorIsDisabled() {
-        when(logger.isErrorEnabled()).thenReturn(false);
+        when(logger.isEnabled(Logger.Level.ERROR)).thenReturn(false);
         when(logger.isInfoEnabled()).thenReturn(true);
 
         HttpProblem problem = HttpProblem.builder()
@@ -88,7 +88,7 @@ class ProblemLoggerTest {
 
     @Test
     void shouldNotLog4xxWhenInfoIsDisabled() {
-        when(logger.isErrorEnabled()).thenReturn(true);
+        when(logger.isEnabled(Logger.Level.ERROR)).thenReturn(true);
         when(logger.isInfoEnabled()).thenReturn(false);
 
         HttpProblem problem = HttpProblem.builder()
@@ -103,7 +103,7 @@ class ProblemLoggerTest {
 
     @Test
     void shouldNotLog5xxWhenErrorIsDisabled() {
-        when(logger.isErrorEnabled()).thenReturn(false);
+        when(logger.isEnabled(Logger.Level.ERROR)).thenReturn(false);
         when(logger.isInfoEnabled()).thenReturn(true);
 
         HttpProblem problem = HttpProblem.builder()


### PR DESCRIPTION
Replaces SLF4J Logger/LoggerFactory with JBoss Logging in `ProblemLogger` and `ProblemProcessor` (and their tests) to align with Quarkus extension best practices and make the logging API consistent across the codebase.

The `client` and `postprocessing` packages already used JBoss Logging - this brings the remaining two files in line.

Note: `MdcPropertiesInjector` still uses `org.slf4j.MDC` since JBoss Logging's MDC class is a separate concern and could be addressed as a follow-up if removing the transitive SLF4J dependency is desired.

Closes #644