### PR TITLE
Make HttpValidationProblem honor HttpProblem's immutability contract

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/validation/HttpValidationProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/validation/HttpValidationProblem.java
@@ -13,15 +13,19 @@ import io.quarkiverse.httpproblem.HttpProblem;
 public class HttpValidationProblem extends HttpProblem {
 
     @Schema(description = "List of validation constraint violations that occurred")
-    List<Violation> violations;
+    private final List<Violation> violations;
 
     public HttpValidationProblem(int status, String title, List<Violation> violations) {
         super(
                 HttpProblem.builder()
                         .withStatus(status)
                         .withTitle(title)
-                        .with("violations", violations));
-        this.violations = violations;
+                        .with("violations", List.copyOf(violations)));
+        this.violations = List.copyOf(violations);
+    }
+
+    public List<Violation> getViolations() {
+        return violations;
     }
 
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/validation/HttpValidationProblemTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/validation/HttpValidationProblemTest.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.httpproblem.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class HttpValidationProblemTest {
+
+    @Test
+    void violationsShouldBeUnmodifiable() {
+        List<Violation> violations = new ArrayList<>();
+        violations.add(Violation.In.body.field("email").message("required"));
+
+        HttpValidationProblem problem = new HttpValidationProblem(400, "Bad Request", violations);
+
+        assertThatThrownBy(() -> problem.getViolations().add(Violation.In.body.field("name").message("required")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void mutatingOriginalListShouldNotAffectProblem() {
+        List<Violation> violations = new ArrayList<>();
+        violations.add(Violation.In.body.field("email").message("required"));
+
+        HttpValidationProblem problem = new HttpValidationProblem(400, "Bad Request", violations);
+
+        violations.add(Violation.In.body.field("name").message("required"));
+
+        assertThat(problem.getViolations()).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void violationsInParametersMapShouldBeUnmodifiable() {
+        List<Violation> violations = List.of(Violation.In.body.field("email").message("required"));
+
+        HttpValidationProblem problem = new HttpValidationProblem(400, "Bad Request", violations);
+        List<Violation> fromParams = (List<Violation>) problem.getParameters().get("violations");
+
+        assertThatThrownBy(() -> fromParams.add(Violation.In.body.field("name").message("required")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void getViolationsShouldReturnAllViolations() {
+        List<Violation> violations = List.of(
+                Violation.In.body.field("email").message("required"),
+                Violation.In.query.field("page").message("must be positive"));
+
+        HttpValidationProblem problem = new HttpValidationProblem(400, "Bad Request", violations);
+
+        assertThat(problem.getViolations()).hasSize(2);
+        assertThat(problem.getViolations().get(0).field).isEqualTo("email");
+        assertThat(problem.getViolations().get(1).field).isEqualTo("page");
+    }
+
+}


### PR DESCRIPTION
HttpProblem is carefully immutable - final fields, unmodifiable maps, Builder-only construction - but HttpValidationProblem stored its violations list as a non-final, package-private field with no defensive copy. This meant callers could mutate the list after construction, and the mutable list leaked through `getParameters().get("violations")` since `unmodifiableMap` only protects map keys, not mutable values inside it.

This changes the violations field to `private final`, uses `List.copyOf()` for a true defensive copy, and adds a `getViolations()` getter.

Fixes #653