### PR TITLE
Fail the build when no JSON provider is detected

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -11,7 +11,8 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.Priorities;
 
 import org.eclipse.microprofile.openapi.OASFilter;
-import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
@@ -137,8 +138,9 @@ public class ProblemProcessor {
     @BuildStep
     FeatureBuildItem createFeature(Capabilities capabilities) {
         if (REST_JSON_CAPABILITIES.stream().noneMatch(capabilities::isPresent)) {
-            logger().error("`quarkus-http-problem` extension is useless without json provider. Please add "
-                    + "`quarkus-rest-jackson` or `quarkus-rest-jsonb` (or classic `resteasy` equivalent) extension to your project.");
+            throw new ConfigurationException(
+                    "The `quarkus-http-problem` extension requires a JSON provider. Please add "
+                            + "`quarkus-rest-jackson` or `quarkus-rest-jsonb` (or classic `resteasy` equivalent) extension to your project.");
         }
         return new FeatureBuildItem(FEATURE_NAME);
     }
@@ -235,9 +237,5 @@ public class ProblemProcessor {
     @BuildStep
     UnremovableBeanBuildItem markPostProcessorsUnremovable() {
         return UnremovableBeanBuildItem.beanTypes(ProblemPostProcessor.class);
-    }
-
-    protected Logger logger() {
-        return Logger.getLogger(FEATURE_NAME);
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
@@ -1,57 +1,36 @@
 package io.quarkiverse.httpproblem.deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Map;
 
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 class ProblemProcessorTest {
 
     static final Capabilities CAPABILITIES_WITH_JSON = new Capabilities(Collections.singleton("io.quarkus.jackson"));
     static final Capabilities CAPABILITIES_WITHOUT_JSON = new Capabilities(Collections.singleton("io.quarkus.resteasy"));
 
-    final Logger logger = mock(Logger.class);
-    final ProblemProcessor problemProcessor = createProcessorWith(logger);
-
-    /**
-     * That's the only way I found to inject mock logger into ProblemProcessor. Quarkus forbids having multiple constructors in
-     * deployment processors, or have fields that are not @BuildItem, which makes it impossible to inject anything via
-     * constructor or even setter.
-     */
-    private ProblemProcessor createProcessorWith(Logger logger) {
-        return new ProblemProcessor() {
-            @Override
-            protected Logger logger() {
-                return logger;
-            }
-        };
-    }
+    final ProblemProcessor problemProcessor = new ProblemProcessor();
 
     @Test
     void featureNameShouldBeValid() {
         assertThat(problemProcessor.createFeature(CAPABILITIES_WITH_JSON).getName())
                 .isEqualTo("http-problem");
-
-        verify(logger, times(0)).error(anyString());
     }
 
     @Test
-    void shouldLogErrorIfMissingJsonCapability() {
-        problemProcessor.createFeature(CAPABILITIES_WITHOUT_JSON);
-
-        verify(logger).error("`quarkus-http-problem` extension is useless without json provider. "
-                + "Please add `quarkus-rest-jackson` or `quarkus-rest-jsonb` (or classic `resteasy` equivalent) extension to your project.");
+    void shouldFailBuildIfMissingJsonCapability() {
+        assertThatThrownBy(() -> problemProcessor.createFeature(CAPABILITIES_WITHOUT_JSON))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("quarkus-rest-jackson");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
When no JSON provider capability is detected (no Jackson or JSON-B extension), ProblemProcessor.createFeature() previously logged an error but still produced the FeatureBuildItem. This meant the extension registered as active but would produce broken responses at runtime since there was no serializer for application/problem+json.

Now throws a ConfigurationException to fail the build immediately with a clear message. Also removes the now-unused logger() method and simplifies the test (no more mock logger needed).

Fixes #655