### PR TITLE
Narrow exception handling and raise log level in ThrowingHttpProblemClientExceptionMapper

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.httpproblem.client;
 
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -29,8 +30,8 @@ public class ThrowingHttpProblemClientExceptionMapper implements ResponseExcepti
             return HttpProblem.builder(returnedProblem)
                     .withInstance(null)
                     .build();
-        } catch (Exception e) {
-            log.debug("Failed to deserialize application/problem+json response body", e);
+        } catch (ProcessingException | IllegalStateException e) {
+            log.warn("Failed to deserialize application/problem+json response body", e);
             return null; // Let others handle unreadable responses
         }
     }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapper.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.httpproblem.client;
 
-import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -30,7 +29,7 @@ public class ThrowingHttpProblemClientExceptionMapper implements ResponseExcepti
             return HttpProblem.builder(returnedProblem)
                     .withInstance(null)
                     .build();
-        } catch (ProcessingException | IllegalStateException e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to deserialize application/problem+json response body", e);
             return null; // Let others handle unreadable responses
         }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapperTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/client/ThrowingHttpProblemClientExceptionMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.core.Response;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -60,6 +61,33 @@ class ThrowingHttpProblemClientExceptionMapperTest {
 
         // when
         Throwable mappedThrowable = mapper.toThrowable(nonProblemResponse);
+
+        // then
+        assertThat(mappedThrowable).isNull();
+    }
+
+    @Test
+    void shouldReturnNullWhenDeserializationFails() {
+        // given - a response that claims to be problem+json but has an unreadable entity
+        Response badProblemResponse = Response.status(500)
+                .type(HttpProblem.MEDIA_TYPE)
+                .entity("not valid json")
+                .build();
+
+        // when
+        Throwable mappedThrowable = mapper.toThrowable(badProblemResponse);
+
+        // then - returns null so other mappers can handle it
+        assertThat(mappedThrowable).isNull();
+    }
+
+    @Test
+    void shouldReturnNullForNullMediaType() {
+        // given
+        Response noMediaType = Response.status(400).build();
+
+        // when
+        Throwable mappedThrowable = mapper.toThrowable(noMediaType);
 
         // then
         assertThat(mappedThrowable).isNull();


### PR DESCRIPTION
The catch block previously caught Exception (the broadest type) and logged at debug level, which is typically off in production. When a REST client failed to deserialize a problem+json response, there was zero diagnostic trail.

This narrows the catch to RuntimeException (which covers all exceptions readEntity() can throw - ProcessingException, IllegalStateException, and implementation-specific subclasses - while excluding checked exceptions) and raises the log level to warn so deserialization failures are visible in production logs.

Note: the original approach tried narrowing to just ProcessingException | IllegalStateException per the JAX-RS spec, but Quarkus REST client reactive throws other RuntimeException subclasses on deserialization failure, so the broader RuntimeException catch is needed for compatibility.

Fixes #657